### PR TITLE
Do not accept args without command

### DIFF
--- a/aci.go
+++ b/aci.go
@@ -1162,6 +1162,10 @@ func readDockerConfigJSONSecret(secret *v1.Secret, ips []aci.ImageRegistryCreden
 func (p *ACIProvider) getContainers(pod *v1.Pod) ([]aci.Container, error) {
 	containers := make([]aci.Container, 0, len(pod.Spec.Containers))
 	for _, container := range pod.Spec.Containers {
+
+		if len(container.Command) == 0 && len(container.Args) > 0 {
+			return nil, errdefs.InvalidInput("ACI does not support providing args without specifying the command. Please supply both command and args to the pod spec.")
+		}
 		c := aci.Container{
 			Name: container.Name,
 			ContainerProperties: aci.ContainerProperties{


### PR DESCRIPTION
As ACI currently combined args + command, a pod
with args and no command will have un-expected behaviour.

This blocks the un-expected behavior.

Related: #10

Signed-off-by: Graham Hayes <gr@ham.ie>