### PR TITLE
Set transport to not reuse conns

### DIFF
--- a/aci.go
+++ b/aci.go
@@ -330,9 +330,9 @@ func (p *ACIProvider) setupCapacity(ctx context.Context) error {
 	logger := log.G(ctx).WithField("method", "setupCapacity")
 
 	// Set sane defaults for Capacity in case config is not supplied
-	p.cpu = "800"
+	p.cpu = "10000"
 	p.memory = "4Ti"
-	p.pods = "800"
+	p.pods = "5000"
 
 	if cpuQuota := os.Getenv("ACI_QUOTA_CPU"); cpuQuota != "" {
 		p.cpu = cpuQuota

--- a/client/client.go
+++ b/client/client.go
@@ -60,7 +60,10 @@ func NewClient(auth *Authentication, baseURI string, userAgent []string) (*Clien
 	}
 
 	uat := userAgentTransport{
-		base:      http.DefaultTransport,
+		base: &http.Transport{
+			DisableKeepAlives:   true,
+			MaxIdleConnsPerHost: -1,
+		},
 		userAgent: nonEmptyUserAgent,
 		client:    client,
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -29,6 +29,11 @@ type userAgentTransport struct {
 	client    *Client
 }
 
+var (
+	concurrentConnections          = 20
+	throttlingAdditionalRetryCount = 3
+)
+
 // NewClient creates a new Azure API client from an Authentication struct and BaseURI.
 func NewClient(auth *Authentication, baseURI string, userAgent []string) (*Client, error) {
 	resource, err := getResourceForToken(auth, baseURI)
@@ -59,10 +64,12 @@ func NewClient(auth *Authentication, baseURI string, userAgent []string) (*Clien
 		}
 	}
 
+	// As go transport doesn't support a away to force close (not reuse) a specific connection in a selective way
+	// after rountrip completes, we'll disable keepalives.
 	uat := userAgentTransport{
 		base: &http.Transport{
 			DisableKeepAlives:   true,
-			MaxIdleConnsPerHost: -1,
+			MaxIdleConnsPerHost: concurrentConnections,
 		},
 		userAgent: nonEmptyUserAgent,
 		client:    client,
@@ -103,6 +110,17 @@ func (t userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error)
 
 	// Add the authorization header.
 	newReq.Header["Authorization"] = []string{fmt.Sprintf("Bearer %s", t.client.BearerAuthorizer.tokenProvider.OAuthToken())}
+
+	var retries int
+	for retries = 0; retries < throttlingAdditionalRetryCount; retries++ {
+		response, err := t.base.RoundTrip(&newReq)
+		if err == nil && response.StatusCode == 429 {
+			// We hit throttling, retry to hopefully hit another ARM instance.
+			continue
+		}
+
+		return response, err
+	}
 
 	return t.base.RoundTrip(&newReq)
 }

--- a/cmd/virtual-kubelet/main.go
+++ b/cmd/virtual-kubelet/main.go
@@ -31,9 +31,10 @@ import (
 )
 
 var (
-	buildVersion = "N/A"
-	buildTime    = "N/A"
-	k8sVersion   = "v1.14.3" // This should follow the version of k8s.io/kubernetes we are importing
+	buildVersion    = "N/A"
+	buildTime       = "N/A"
+	k8sVersion      = "v1.14.3" // This should follow the version of k8s.io/kubernetes we are importing
+	numberOfWorkers = 40
 )
 
 func main() {
@@ -50,6 +51,7 @@ func main() {
 	}
 	o.Provider = "azure"
 	o.Version = strings.Join([]string{k8sVersion, "vk-azure-aci", buildVersion}, "-")
+	o.PodSyncWorkers = numberOfWorkers
 
 	node, err := cli.New(ctx,
 		cli.WithBaseOpts(o),

--- a/cmd/virtual-kubelet/main.go
+++ b/cmd/virtual-kubelet/main.go
@@ -34,7 +34,7 @@ var (
 	buildVersion    = "N/A"
 	buildTime       = "N/A"
 	k8sVersion      = "v1.14.3" // This should follow the version of k8s.io/kubernetes we are importing
-	numberOfWorkers = 40
+	numberOfWorkers = 25
 )
 
 func main() {


### PR DESCRIPTION
Avoiding the ARM throttling issues. when same connection to same ARM instance is reused.