### PR TITLE
Support to authenticate through user identity

### DIFF
--- a/client/aci/client_test.go
+++ b/client/aci/client_test.go
@@ -144,6 +144,7 @@ func TestNewMsiClient(t *testing.T) {
 	err = restClient.DeleteContainerGroup(context.Background(), resourceGroup, containerGroup)
 	if err != nil {
 		// Expected as no proper response is sent back.
+		return
 	}
 }
 

--- a/client/aci/client_test.go
+++ b/client/aci/client_test.go
@@ -141,7 +141,10 @@ func TestNewMsiClient(t *testing.T) {
 
 	c.SetTokenProviderTestSender(ds)
 
-	restClient.DeleteContainerGroup(context.Background(), resourceGroup, containerGroup)
+	err = restClient.DeleteContainerGroup(context.Background(), resourceGroup, containerGroup)
+	if err != nil {
+		// Expected as no proper response is sent back.
+	}
 }
 
 func TestCreateContainerGroupFails(t *testing.T) {

--- a/client/auth.go
+++ b/client/auth.go
@@ -23,6 +23,8 @@ type Authentication struct {
 	SQLManagementEndpoint   string `json:"sqlManagementEndpointUrl,omitempty"`
 	GalleryEndpoint         string `json:"galleryEndpointUrl,omitempty"`
 	ManagementEndpoint      string `json:"managementEndpointUrl,omitempty"`
+	UseUserIdentity         bool   `json:"useUserIdentity,omitempty"`
+	UserIdentityClientId    string `json:"userIdentityClientId,omitempty"`
 }
 
 // NewAuthentication returns an authentication struct from user provided


### PR DESCRIPTION
This is a requirement as AKS clusters will not share the SP anymore, and instead a separate user identity per-addon/system deployment will be used.