### PR TITLE
Have step to install Microsoft pgp key match official docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ Download and run the [Azure CLI Installer (MSI)](https://aka.ms/InstallAzureCliW
     ```
 2. Run the following commands to install the Azure CLI and its dependencies:
     ```cli
-    sudo apt-key adv --keyserver packages.microsoft.com --recv-keys 52E16F86FEE04B979B07E28DB02C46DF417A0893
+    curl -sL https://packages.microsoft.com/keys/microsoft.asc |
+        gpg --dearmor |
+        sudo tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null
     sudo apt-get install apt-transport-https
     sudo apt-get update && sudo apt-get install azure-cli
     ```


### PR DESCRIPTION
Current step to use apt-key times out on 18.04 and 19.10:
```
$ sudo apt-key adv --verbose --keyserver packages.microsoft.com --recv-keys 52E16F86FEE04B979B07E28DB02C46DF417A0893
Executing: /tmp/apt-key-gpghome.rNItUw1LZq/gpg.1.sh --verbose --keyserver packages.microsoft.com --recv-keys 52E16F86FEE04B979B07E28DB02C46DF417A0893
gpg: no running Dirmngr - starting '/usr/bin/dirmngr'
gpg: waiting for the dirmngr to come up ... (5s)
gpg: connection to dirmngr established
gpg: keyserver receive failed: Connection timed out
$ 
```

https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-apt?view=azure-cli-latest
instead uses a curl/gpg/tee pipe which seems more reliable.