### PR TITLE
update for Helm 3 and Kubernete 1.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM golang:1.12 as builder
+FROM golang:1.15 as builder
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
 COPY . /go/src/github.com/virtual-kubelet/azure-aci
 WORKDIR /go/src/github.com/virtual-kubelet/azure-aci
-RUN make build
+RUN make clean && make build
 RUN cp bin/virtual-kubelet /usr/bin/virtual-kubelet
 
-FROM ubuntu:16.04
+FROM scratch
 COPY --from=builder /usr/bin/virtual-kubelet /usr/bin/virtual-kubelet
 COPY --from=builder /etc/ssl/certs/ /etc/ssl/certs
 ENTRYPOINT [ "/usr/bin/virtual-kubelet" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /go/src/github.com/virtual-kubelet/azure-aci
 RUN make build
 RUN cp bin/virtual-kubelet /usr/bin/virtual-kubelet
 
-FROM scratch
+FROM ubuntu:16.04
 COPY --from=builder /usr/bin/virtual-kubelet /usr/bin/virtual-kubelet
 COPY --from=builder /etc/ssl/certs/ /etc/ssl/certs
 ENTRYPOINT [ "/usr/bin/virtual-kubelet" ]

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Install `kubectl` by running the following command:
 az aks install-cli
 ```
 
-### Install the Helm CLI
+### Install the Helm 3.x CLI
 
 [Helm](https://github.com/kubernetes/helm) is a tool for installing pre-configured applications on Kubernetes.
 Install `helm` by running the following command:
@@ -224,7 +224,7 @@ export VK_RELEASE=virtual-kubelet-latest
 export NODE_NAME=virtual-kubelet
 export CHART_URL=https://github.com/virtual-kubelet/virtual-kubelet/raw/master/charts/$VK_RELEASE.tgz
 
-helm install "$CHART_URL" --name "$RELEASE_NAME" \
+helm install "$RELEASE_NAME" "$CHART_URL" \
   --set provider=azure \
   --set providers.azure.targetAKS=true \
   --set providers.azure.masterUri=$MASTER_URI
@@ -236,7 +236,7 @@ RELEASE_NAME=virtual-kubelet
 NODE_NAME=virtual-kubelet
 CHART_URL=https://github.com/virtual-kubelet/virtual-kubelet/raw/master/charts/$VK_RELEASE.tgz
 
-helm install "$CHART_URL" --name "$RELEASE_NAME" \
+helm install "$RELEASE_NAME" "$CHART_URL" \
   --set provider=azure \
   --set rbac.install=true \
   --set providers.azure.targetAKS=false \

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This document details configuring the Virtual Kubelet ACI provider.
 * [Set-up virtual node in AKS](#set-up-virtual-node-in-AKS)
 * [Quick set-up with the ACI Connector](#quick-set-up-with-the-aci-connector)
 * [Manual set-up](#manual-set-up)
-* [Create a cluster with a Virtual Network](#create-an-aks-cluster-with-vnet)
+* [Create a AKS cluster with a Virtual Network](#create-an-aks-cluster-with-vnet)
 * [Validate the Virtual Kubelet ACI provider](#validate-the-virtual-kubelet-aci-provider)
 * [Schedule a pod in ACI](#schedule-a-pod-in-aci)
 * [Work arounds](#work-arounds-for-the-aci-connector)
@@ -430,10 +430,22 @@ helm install "$CHART_URL" --name "$RELEASE_NAME" \
 For any other type of cluster: 
 
 ```cli
+# the resource group where the virtual network localte in
+export ACI_VNET_RESOURCE_GROUP=<resource group>
+
+# the virtual network name where container will deploy to
+export ACI_VNET_NAME=<virtual network name>
+# subnet name where ACI will deploy to. Virtual Kubelet will automatically create subnet resource if it not exists
+export ACI_SUBNET_NAME=<subnet name>
+# subnet's IP range, for example 10.1.0.0/16. You don't need specific this system variable if subnet has been exists
+export ACI_SUBNET_RANGE=<subnet name where ACI will run in>
+
 helm install "$CHART_URL" --name "$RELEASE_NAME" \
   --set provider=azure \
   --set providers.azure.targetAKS=false \
   --set providers.azure.vnet.enabled=true \
+  --set providers.azure.vnet.vnetResourceGroup=$ACI_VNET_RESOURCE_GROUP \
+  --set providers.azure.vnet.vnetName=$ACI_VNET_NAME \
   --set providers.azure.vnet.subnetName=$ACI_SUBNET_NAME \
   --set providers.azure.vent.subnetCidr=$ACI_SUBNET_RANGE \
   --set providers.azure.vnet.kubeDnsIp=$KUBE_DNS_IP \
@@ -442,7 +454,10 @@ helm install "$CHART_URL" --name "$RELEASE_NAME" \
   --set providers.azure.aciResourceGroup=$AZURE_RG \
   --set providers.azure.aciRegion=$ACI_REGION \
   --set providers.azure.masterUri=$MASTER_URI
+  --set providers.azure.clientId=$AZURE_CLIENT_ID \
+  --set providers.azure.clientKey=$AZURE_CLIENT_SECRET \
   ```
+
 
 ## Validate the Virtual Kubelet ACI provider
 

--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ CHART_URL=https://github.com/virtual-kubelet/virtual-kubelet/raw/master/charts/$
 If your cluster is an AKS cluster: 
 
 ```cli
-helm install "$CHART_URL" --name "$RELEASE_NAME" \
+helm install "$RELEASE_NAME" "$CHART_URL" \
   --set provider=azure \
   --set providers.azure.targetAKS=true \
   --set providers.azure.vnet.enabled=true \
@@ -440,7 +440,7 @@ export ACI_SUBNET_NAME=<subnet name>
 # subnet's IP range, for example 10.1.0.0/16. You don't need specific this system variable if subnet has been exists
 export ACI_SUBNET_RANGE=<subnet name where ACI will run in>
 
-helm install "$CHART_URL" --name "$RELEASE_NAME" \
+helm install "$RELEASE_NAME" "$CHART_URL" \
   --set provider=azure \
   --set providers.azure.targetAKS=false \
   --set providers.azure.vnet.enabled=true \

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/gorilla/websocket v1.4.0
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.2
-	github.com/virtual-kubelet/node-cli v0.3.0
+	github.com/virtual-kubelet/node-cli v0.3.1
 	github.com/virtual-kubelet/virtual-kubelet v1.3.0
 	go.opencensus.io v0.21.0
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e

--- a/go.sum
+++ b/go.sum
@@ -589,6 +589,7 @@ github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/virtual-kubelet/node-cli v0.3.0 h1:gPDlxbx8sirQWrd7tA92ONkqdltZJEciHPpP0NuSots=
 github.com/virtual-kubelet/node-cli v0.3.0/go.mod h1:82mtWxoh93U2Tu/XySeYmMrhE60FMozD6hWbSqzTzo4=
+github.com/virtual-kubelet/node-cli v0.3.1/go.mod h1:82mtWxoh93U2Tu/XySeYmMrhE60FMozD6hWbSqzTzo4=
 github.com/virtual-kubelet/virtual-kubelet v1.3.0 h1:ixQRrPcVcRHoMO0WcQolyOs/ScZqa7kryYBiZE3Xa94=
 github.com/virtual-kubelet/virtual-kubelet v1.3.0/go.mod h1:kuDs8O1dU0pLMLxzx7zvf4haeS6jB3YMbD73zWe1sV4=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=

--- a/go.sum
+++ b/go.sum
@@ -587,8 +587,7 @@ github.com/valyala/fasthttp v1.2.0/go.mod h1:4vX61m6KN+xDduDNwXrhIAVZaZaZiQ1luJk
 github.com/valyala/quicktemplate v1.1.1/go.mod h1:EH+4AkTd43SvgIbQHYu59/cJyxDoOVRUAfrukLPuGJ4=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
-github.com/virtual-kubelet/node-cli v0.3.0 h1:gPDlxbx8sirQWrd7tA92ONkqdltZJEciHPpP0NuSots=
-github.com/virtual-kubelet/node-cli v0.3.0/go.mod h1:82mtWxoh93U2Tu/XySeYmMrhE60FMozD6hWbSqzTzo4=
+github.com/virtual-kubelet/node-cli v0.3.1 h1:2vJzLbRCDRBHXwlsd4UOU35ZhkSsLLg6vbsaZoWiNno=
 github.com/virtual-kubelet/node-cli v0.3.1/go.mod h1:82mtWxoh93U2Tu/XySeYmMrhE60FMozD6hWbSqzTzo4=
 github.com/virtual-kubelet/virtual-kubelet v1.3.0 h1:ixQRrPcVcRHoMO0WcQolyOs/ScZqa7kryYBiZE3Xa94=
 github.com/virtual-kubelet/virtual-kubelet v1.3.0/go.mod h1:kuDs8O1dU0pLMLxzx7zvf4haeS6jB3YMbD73zWe1sV4=

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -78,6 +78,10 @@ spec:
           value: {{ printf "helm-chart/other/%s/%s" $.Chart.Name $.Chart.Version }}
 {{- end }}
 {{- if .vnet.enabled }}
+        - name: ACI_VNET_RESOURCE_GROUP
+          value: {{ .vnet.vnetResourceGroup}}
+        - name: ACI_VNET_NAME
+          value: {{ .vnet.vnetName}}
         - name: ACI_SUBNET_NAME
           value: {{ required "subnetName is required" .vnet.subnetName }}
         - name: ACI_SUBNET_CIDR

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "vk.fullname" . }}
@@ -6,12 +6,17 @@ metadata:
     component: kubelet
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "vk.fullname" . }}
   template:
     metadata:
 {{ include "vk.labels" . | indent 6 }}
         component: kubelet
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+      labels:
+        app: {{ template "vk.fullname" . }}
     spec:
       containers:
       - name: {{ template "vk.fullname" . }}

--- a/helm/templates/secrets.yaml
+++ b/helm/templates/secrets.yaml
@@ -5,7 +5,7 @@ metadata:
 {{ include "vk.labels" . | indent 2 }}
 type: Opaque
 data:
-{{- if (not .Values.apiserverCert) and (not .Values.apiserverKey) }}
+{{- if and (not .Values.apiserverCert) (not .Values.apiserverKey) }}
 {{- $ca := genCA "virtual-kubelet-ca" 3650 }}
 {{- $cn := printf "%s-virtual-kubelet-apiserver" .Release.Name }}
 {{- $altName1 := printf "%s-virtual-kubelet-apiserver.%s" .Release.Name .Release.Namespace }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -5,6 +5,7 @@ image:
   repositoryReadOnlyPrincipalId: 98961725-8311-48ef-8f11-2cc3911ee807
   repositoryReadOnlyPrincipalSecret: MH]/FD2.9RwhDmQZQAxu.p0z4fBuR=DG
   tag: 1.2.1.2
+  pullPolicy: Always
 
 nodeName: "virtual-node-aci-linux-helm"
 nodeOsType: "Linux"
@@ -44,6 +45,8 @@ providers:
       clusterResourceId: 
     vnet:
       enabled: false 
+      vnetResourceGroup:
+      vnetName: 
       subnetName: virtual-node-aci
       ## If subnet already created on vnet, don't pass subnetCidr if it doesn't match the existing one.
       ## If cluster subnet has a different range, please specify its value in clusterCidr

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@ image:
   name: virtual-kubelet
   repositoryReadOnlyPrincipalId: 98961725-8311-48ef-8f11-2cc3911ee807
   repositoryReadOnlyPrincipalSecret: MH]/FD2.9RwhDmQZQAxu.p0z4fBuR=DG
-  tag: 1.1
+  tag: 1.2.1.2
 
 nodeName: "virtual-node-aci-linux-helm"
 nodeOsType: "Linux"
@@ -43,7 +43,7 @@ providers:
       workspaceKey: 
       clusterResourceId: 
     vnet:
-      enabled: true
+      enabled: false 
       subnetName: virtual-node-aci
       ## If subnet already created on vnet, don't pass subnetCidr if it doesn't match the existing one.
       ## If cluster subnet has a different range, please specify its value in clusterCidr
@@ -60,6 +60,6 @@ rbac:
   install: true
   serviceAccountName: virtual-kubelet-helm
   ## RBAC api version
-  apiVersion: v1beta1
+  apiVersion: v1
   ## Cluster role reference
   roleRef: cluster-admin

--- a/provider/aci.go
+++ b/provider/aci.go
@@ -217,6 +217,13 @@ func NewACIProvider(config string, rm *manager.ResourceManager, nodeName, operat
 		}
 	}
 
+	if vnetName := os.Getenv("ACI_VNET_NAME"); vnetName != "" {
+		p.vnetName = vnetName
+	}
+	if vnetResourceGroup := os.Getenv("ACI_VNET_RESOURCE_GROUP"); vnetResourceGroup != "" {
+		p.vnetResourceGroup = vnetResourceGroup
+	}
+
 	if clientID := os.Getenv("AZURE_CLIENT_ID"); clientID != "" {
 		azAuth.ClientID = clientID
 	}


### PR DESCRIPTION
Make changes for:
1. update document for Helm 3. See issue #57 and #56 
2. update the Kubernete deployment  version from extensions/v1beta1 to apps/v1, since extensions/v1beta1 has been not supported from Kubernete 1.6. see issue #44 
3. update the code to support install ACI Virtual Kubelet in Non-AKS cluster, and update corresponding documents.
