### PR TITLE
Disable trigger on Azure-pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 # Pipeline
 
-trigger:
-- master
+## Disabled the trigger, as it's no longer used as part of validating builds.
+trigger: none
 
 pool:
   name: Hosted Ubuntu 1604


### PR DESCRIPTION
We're disabling this trigger, as the pipeline is failing, but also not required.