### PR TITLE
Ensure label node.kubernetes.io/exclude-from-external-load-balancers is added to virtual node

### DIFF
--- a/provider/aci.go
+++ b/provider/aci.go
@@ -1068,6 +1068,7 @@ func (p *ACIProvider) ConfigureNode(ctx context.Context, node *v1.Node) {
 	node.Status.DaemonEndpoints = p.nodeDaemonEndpoints()
 	node.Status.NodeInfo.OperatingSystem = p.operatingSystem
 	node.ObjectMeta.Labels["alpha.service-controller.kubernetes.io/exclude-balancer"] = "true"
+	node.ObjectMeta.Labels["node.kubernetes.io/exclude-from-external-load-balancers"] = "true"
 }
 
 // GetPodStatus returns the status of a pod by name that is running inside ACI


### PR DESCRIPTION
"alpha.service-controller.kubernetes.io/exclude-balancer" has been removed since v1.19.0, we should ensure the new label "node.kubernetes.io/exclude-from-external-load-balancers" is added for virtual node:

```
    // labelNodeRoleExcludeBalancer specifies that the node should not be considered as a target
    // for external load-balancers which use nodes as a second hop (e.g. many cloud LBs which only
    // understand nodes). For services that use externalTrafficPolicy=Local, this may mean that
    // any backends on excluded nodes are not reachable by those external load-balancers.
    // Implementations of this exclusion may vary based on provider. This label is honored starting
    // in 1.16 when the ServiceNodeExclusion gate is on.
    labelNodeRoleExcludeBalancer = "node.kubernetes.io/exclude-from-external-load-balancers"
    // labelAlphaNodeRoleExcludeBalancer specifies that the node should be
    // exclude from load balancers created by a cloud provider. This label is deprecated and will
    // be removed in 1.18.
    labelAlphaNodeRoleExcludeBalancer = "alpha.service-controller.kubernetes.io/exclude-balancer"
```