### PR TITLE
Bump node-cli to 0.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/gorilla/websocket v1.4.0
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.2
-	github.com/virtual-kubelet/node-cli v0.3.1
+	github.com/virtual-kubelet/node-cli v0.4.0
 	github.com/virtual-kubelet/virtual-kubelet v1.3.0
 	go.opencensus.io v0.21.0
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e

--- a/go.sum
+++ b/go.sum
@@ -587,8 +587,8 @@ github.com/valyala/fasthttp v1.2.0/go.mod h1:4vX61m6KN+xDduDNwXrhIAVZaZaZiQ1luJk
 github.com/valyala/quicktemplate v1.1.1/go.mod h1:EH+4AkTd43SvgIbQHYu59/cJyxDoOVRUAfrukLPuGJ4=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
-github.com/virtual-kubelet/node-cli v0.3.1 h1:2vJzLbRCDRBHXwlsd4UOU35ZhkSsLLg6vbsaZoWiNno=
-github.com/virtual-kubelet/node-cli v0.3.1/go.mod h1:82mtWxoh93U2Tu/XySeYmMrhE60FMozD6hWbSqzTzo4=
+github.com/virtual-kubelet/node-cli v0.4.0 h1:OlPAxQhYSXv8D0WzVJaSa902u8+Z7AW+f8+y8NLUroY=
+github.com/virtual-kubelet/node-cli v0.4.0/go.mod h1:82mtWxoh93U2Tu/XySeYmMrhE60FMozD6hWbSqzTzo4=
 github.com/virtual-kubelet/virtual-kubelet v1.3.0 h1:ixQRrPcVcRHoMO0WcQolyOs/ScZqa7kryYBiZE3Xa94=
 github.com/virtual-kubelet/virtual-kubelet v1.3.0/go.mod h1:kuDs8O1dU0pLMLxzx7zvf4haeS6jB3YMbD73zWe1sV4=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=


### PR DESCRIPTION
This adds on-by-default TLS client authentication.
If client certs are not specified then the API server will not be setup.

Full diff: https://github.com/virtual-kubelet/node-cli/compare/v0.3.1..v0.4.0
Release notes: https://github.com/virtual-kubelet/node-cli/releases/tag/v0.4.0

Before releasing with this change, we'll need to work out how to deal with certificates.