### PR TITLE
Add kubernetes.azure.com/managed=false label for virtual node

### DIFF
--- a/provider/aci.go
+++ b/provider/aci.go
@@ -1072,6 +1072,9 @@ func (p *ACIProvider) ConfigureNode(ctx context.Context, node *v1.Node) {
 	node.Status.NodeInfo.OperatingSystem = p.operatingSystem
 	node.ObjectMeta.Labels["alpha.service-controller.kubernetes.io/exclude-balancer"] = "true"
 	node.ObjectMeta.Labels["node.kubernetes.io/exclude-from-external-load-balancers"] = "true"
+
+	// Virtual node would be skipped for cloud provider operations (e.g. CP should not add route).
+	node.ObjectMeta.Labels["kubernetes.azure.com/managed"] = "false"
 }
 
 // GetPodStatus returns the status of a pod by name that is running inside ACI

--- a/provider/aci_test.go
+++ b/provider/aci_test.go
@@ -852,6 +852,35 @@ func ptrQuantity(q resource.Quantity) *resource.Quantity {
 	return &q
 }
 
+func TestConfigureNode(t *testing.T) {
+	_, _, provider, err := prepareMocks()
+	if err != nil {
+		t.Fatal("Unable to prepare the mocks", err)
+	}
+
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "virtual-kubelet",
+			Labels: map[string]string{
+				"type":                   "virtual-kubelet",
+				"kubernetes.io/role":     "agent",
+				"kubernetes.io/hostname": "virtual-kubelet",
+			},
+		},
+		Spec: v1.NodeSpec{},
+		Status: v1.NodeStatus{
+			NodeInfo: v1.NodeSystemInfo{
+				Architecture:   "amd64",
+				KubeletVersion: "1.18.4",
+			},
+		},
+	}
+	provider.ConfigureNode(context.TODO(), node)
+	assert.Equal(t, "true", node.ObjectMeta.Labels["alpha.service-controller.kubernetes.io/exclude-balancer"], "exclude-balancer label doesn't match")
+	assert.Equal(t, "true", node.ObjectMeta.Labels["node.kubernetes.io/exclude-from-external-load-balancers"], "exclude-from-external-load-balancers label doesn't match")
+	assert.Equal(t, "false", node.ObjectMeta.Labels["kubernetes.azure.com/managed"], "kubernetes.azure.com/managed label doesn't match")
+}
+
 func TestCreatePodWithNamedLivenessProbe(t *testing.T) {
 	_, aciServerMocker, provider, err := prepareMocks()
 


### PR DESCRIPTION
Virtual node should not be added to LoadBalancer backend address pool and route tables should not be updated for it either. Hence, this PR marks virtual node as unmanaged.

Refer cloud provider docs https://kubernetes-sigs.github.io/cloud-provider-azure/topics/cross-resource-group-nodes/#unmanaged-nodes.

Fix #89.