### PR TITLE
e2e: generate ssh keys for cluster

### DIFF
--- a/hack/e2e/aks.sh
+++ b/hack/e2e/aks.sh
@@ -100,7 +100,8 @@ az aks create \
     --vnet-subnet-id "$aks_subnet_id" \
     --dns-service-ip "$KUBE_DNS_IP" \
     --assign-kubelet-identity "$node_identity_id" \
-    --assign-identity "$cluster_identity_id"
+    --assign-identity "$cluster_identity_id" \
+    --generate-ssh-keys
 
 az role assignment create \
     --role "Network Contributor" \


### PR DESCRIPTION
In CI cluster creation fails due to missing ssh keys.
This just adds the flag to cluster creation to have it generate keys for
us.