### PR TITLE
Add ACI Spot virtual nodes support to virtual kubelet

### DIFF
--- a/client/aci/types.go
+++ b/client/aci/types.go
@@ -28,6 +28,16 @@ const (
 	OnFailure ContainerGroupRestartPolicy = "OnFailure"
 )
 
+// ContainerGroupPriority enumerates the values for container group priority.
+type ContainerGroupPriority string
+
+const (
+	// Regular specifies the regular priority for container group restart priority.
+	Regular ContainerGroupPriority = "Regular"
+	// Spot specifies the spot priority for container group restart priority.
+	Spot ContainerGroupPriority = "Spot"
+)
+
 // ContainerNetworkProtocol enumerates the values for container network protocol.
 type ContainerNetworkProtocol string
 
@@ -94,7 +104,7 @@ type ContainerGroupProperties struct {
 	Volumes                  []Volume                             `json:"volumes,omitempty"`
 	InstanceView             ContainerGroupPropertiesInstanceView `json:"instanceView,omitempty"`
 	Diagnostics              *ContainerGroupDiagnostics           `json:"diagnostics,omitempty"`
-	SubnetIds           	 []*SubnetIdDefinition            `json:"subnetIds,omitempty"`
+	SubnetIds                []*SubnetIdDefinition                `json:"subnetIds,omitempty"`
 	Extensions               []*Extension                         `json:"extensions,omitempty"`
 	DNSConfig                *DNSConfig                           `json:"dnsConfig,omitempty"`
 }
@@ -105,7 +115,7 @@ type ContainerGroupPropertiesInstanceView struct {
 	State  string  `json:"state,omitempty"`
 }
 
-// SubnetIdDefinition is the subnet ID, the format should be 
+// SubnetIdDefinition is the subnet ID, the format should be
 // /subscriptions/{subscriptionID}/resourceGroups/{ResourceGroup}/providers/Microsoft.Network/virtualNetworks/{VNET}/subnets/{Subnet}
 type SubnetIdDefinition struct {
 	ID string `json:"id,omitempty"`
@@ -242,7 +252,7 @@ type GPUSKU string
 
 const (
 	// K80 specifies the K80 GPU SKU
-	K80  GPUSKU = "K80"
+	K80 GPUSKU = "K80"
 	// P100 specifies the P100 GPU SKU
 	P100 GPUSKU = "P100"
 	// V100 specifies the V100 GPU SKU
@@ -460,7 +470,7 @@ type ExtensionType string
 
 // Supported extension types
 const (
-	ExtensionTypeKubeProxy ExtensionType = "kube-proxy"
+	ExtensionTypeKubeProxy       ExtensionType = "kube-proxy"
 	ExtensionTypeRealtimeMetrics ExtensionType = "realtime-metrics"
 )
 

--- a/provider/aci_test.go
+++ b/provider/aci_test.go
@@ -365,6 +365,244 @@ func TestCreatePodWithGPUSKU(t *testing.T) {
 	}
 }
 
+// Tests create pod with Spot priority in annotation.
+func TestCreatePodWithSpotPriority(t *testing.T) {
+	aadServerMocker := NewAADMock()
+	aciServerMocker := NewACIMock()
+
+	podName := "pod-" + uuid.New().String()
+	podNamespace := "ns-" + uuid.New().String()
+	gpuSKU := aci.GPUSKU("sku-" + uuid.New().String())
+	priority := aci.Spot
+
+	aciServerMocker.OnGetRPManifest = func() (int, interface{}) {
+		manifest := &aci.ResourceProviderManifest{
+			Metadata: &aci.ResourceProviderMetadata{
+				GPURegionalSKUs: []*aci.GPURegionalSKU{
+					&aci.GPURegionalSKU{
+						Location: fakeRegion,
+						SKUs:     []aci.GPUSKU{aci.K80, aci.P100, gpuSKU},
+					},
+				},
+			},
+		}
+
+		return http.StatusOK, manifest
+	}
+
+	provider, err := createTestProvider(aadServerMocker, aciServerMocker, nil)
+	if err != nil {
+		t.Fatalf("failed to create the test provider. %s", err.Error())
+		return
+	}
+
+	aciServerMocker.OnCreate = func(subscription, resourceGroup, containerGroup string, cg *aci.ContainerGroup) (int, interface{}) {
+		assert.Check(t, is.Equal(fakeSubscription, subscription), "Subscription doesn't match")
+		assert.Check(t, is.Equal(fakeResourceGroup, resourceGroup), "Resource group doesn't match")
+		assert.Check(t, cg != nil, "Container group is nil")
+		assert.Check(t, is.Equal(podNamespace+"-"+podName, containerGroup), "Container group name is not expected")
+		assert.Check(t, cg.ContainerGroupProperties.Containers != nil, "Containers should not be nil")
+		assert.Check(t, is.Equal(1, len(cg.ContainerGroupProperties.Containers)), "1 Container is expected")
+		assert.Check(t, is.Equal("nginx", cg.ContainerGroupProperties.Containers[0].Name), "Container nginx is expected")
+		assert.Check(t, cg.ContainerGroupProperties.Containers[0].Resources.Requests != nil, "Container resource requests should not be nil")
+		assert.Check(t, is.Equal(1.98, cg.ContainerGroupProperties.Containers[0].Resources.Requests.CPU), "Request CPU is not expected")
+		assert.Check(t, is.Equal(3.4, cg.ContainerGroupProperties.Containers[0].Resources.Requests.MemoryInGB), "Request Memory is not expected")
+		assert.Check(t, cg.ContainerGroupProperties.Containers[0].Resources.Requests.GPU != nil, "Requests GPU is not expected")
+		assert.Check(t, is.Equal(int32(1), cg.ContainerGroupProperties.Containers[0].Resources.Requests.GPU.Count), "Requests GPU Count is not expected")
+		assert.Check(t, is.Equal(gpuSKU, cg.ContainerGroupProperties.Containers[0].Resources.Requests.GPU.SKU), "Requests GPU SKU is not expected")
+		assert.Check(t, cg.ContainerGroupProperties.Containers[0].Resources.Limits.GPU != nil, "Limits GPU is not expected")
+		assert.Check(t, is.Equal(int32(1), cg.ContainerGroupProperties.Containers[0].Resources.Limits.GPU.Count), "Requests GPU Count is not expected")
+		assert.Check(t, is.Equal(gpuSKU, cg.ContainerGroupProperties.Containers[0].Resources.Limits.GPU.SKU), "Requests GPU SKU is not expected")
+		assert.Check(t, is.Equal(priority, cg.ContainerGroupProperties.Priority), "Container group priority does not match")
+
+		return http.StatusOK, cg
+	}
+	t.Logf((string(priority)))
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: podNamespace,
+			Annotations: map[string]string{
+				gpuTypeAnnotation: string(gpuSKU),
+				"priority":        string(priority),
+			},
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				v1.Container{
+					Name: "nginx",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							"cpu":    resource.MustParse("1.981"),
+							"memory": resource.MustParse("3.49G"),
+						},
+						Limits: v1.ResourceList{
+							gpuResourceName: resource.MustParse("1"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := provider.CreatePod(context.Background(), pod); err != nil {
+		t.Fatal("Failed to create pod", err)
+	}
+}
+
+// Tests create pod with Regular priority in annotation.
+func TestCreatePodWithRegularPriority(t *testing.T) {
+	aadServerMocker := NewAADMock()
+	aciServerMocker := NewACIMock()
+
+	podName := "pod-" + uuid.New().String()
+	podNamespace := "ns-" + uuid.New().String()
+	gpuSKU := aci.GPUSKU("sku-" + uuid.New().String())
+	priority := aci.Regular
+
+	aciServerMocker.OnGetRPManifest = func() (int, interface{}) {
+		manifest := &aci.ResourceProviderManifest{
+			Metadata: &aci.ResourceProviderMetadata{
+				GPURegionalSKUs: []*aci.GPURegionalSKU{
+					&aci.GPURegionalSKU{
+						Location: fakeRegion,
+						SKUs:     []aci.GPUSKU{aci.K80, aci.P100, gpuSKU},
+					},
+				},
+			},
+		}
+
+		return http.StatusOK, manifest
+	}
+
+	provider, err := createTestProvider(aadServerMocker, aciServerMocker, nil)
+	if err != nil {
+		t.Fatalf("failed to create the test provider. %s", err.Error())
+		return
+	}
+
+	aciServerMocker.OnCreate = func(subscription, resourceGroup, containerGroup string, cg *aci.ContainerGroup) (int, interface{}) {
+		assert.Check(t, is.Equal(fakeSubscription, subscription), "Subscription doesn't match")
+		assert.Check(t, is.Equal(fakeResourceGroup, resourceGroup), "Resource group doesn't match")
+		assert.Check(t, cg != nil, "Container group is nil")
+		assert.Check(t, is.Equal(podNamespace+"-"+podName, containerGroup), "Container group name is not expected")
+		assert.Check(t, cg.ContainerGroupProperties.Containers != nil, "Containers should not be nil")
+		assert.Check(t, is.Equal(1, len(cg.ContainerGroupProperties.Containers)), "1 Container is expected")
+		assert.Check(t, is.Equal("nginx", cg.ContainerGroupProperties.Containers[0].Name), "Container nginx is expected")
+		assert.Check(t, cg.ContainerGroupProperties.Containers[0].Resources.Requests != nil, "Container resource requests should not be nil")
+		assert.Check(t, is.Equal(1.98, cg.ContainerGroupProperties.Containers[0].Resources.Requests.CPU), "Request CPU is not expected")
+		assert.Check(t, is.Equal(3.4, cg.ContainerGroupProperties.Containers[0].Resources.Requests.MemoryInGB), "Request Memory is not expected")
+		assert.Check(t, cg.ContainerGroupProperties.Containers[0].Resources.Requests.GPU != nil, "Requests GPU is not expected")
+		assert.Check(t, is.Equal(int32(1), cg.ContainerGroupProperties.Containers[0].Resources.Requests.GPU.Count), "Requests GPU Count is not expected")
+		assert.Check(t, is.Equal(gpuSKU, cg.ContainerGroupProperties.Containers[0].Resources.Requests.GPU.SKU), "Requests GPU SKU is not expected")
+		assert.Check(t, cg.ContainerGroupProperties.Containers[0].Resources.Limits.GPU != nil, "Limits GPU is not expected")
+		assert.Check(t, is.Equal(int32(1), cg.ContainerGroupProperties.Containers[0].Resources.Limits.GPU.Count), "Requests GPU Count is not expected")
+		assert.Check(t, is.Equal(gpuSKU, cg.ContainerGroupProperties.Containers[0].Resources.Limits.GPU.SKU), "Requests GPU SKU is not expected")
+		assert.Check(t, is.Equal(priority, cg.ContainerGroupProperties.Priority), "Container group priority does not match")
+
+		return http.StatusOK, cg
+	}
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: podNamespace,
+			Annotations: map[string]string{
+				gpuTypeAnnotation: string(gpuSKU),
+				"priority":        string(priority),
+			},
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				v1.Container{
+					Name: "nginx",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							"cpu":    resource.MustParse("1.981"),
+							"memory": resource.MustParse("3.49G"),
+						},
+						Limits: v1.ResourceList{
+							gpuResourceName: resource.MustParse("1"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := provider.CreatePod(context.Background(), pod); err != nil {
+		t.Fatal("Failed to create pod", err)
+	}
+}
+
+// Tests create pod with Invalid priority in annotation.
+func TestCreatePodWithInvalidPriority(t *testing.T) {
+	aadServerMocker := NewAADMock()
+	aciServerMocker := NewACIMock()
+
+	podName := "pod-" + uuid.New().String()
+	podNamespace := "ns-" + uuid.New().String()
+	gpuSKU := aci.GPUSKU("sku-" + uuid.New().String())
+	priority := "test"
+
+	aciServerMocker.OnGetRPManifest = func() (int, interface{}) {
+		manifest := &aci.ResourceProviderManifest{
+			Metadata: &aci.ResourceProviderMetadata{
+				GPURegionalSKUs: []*aci.GPURegionalSKU{
+					&aci.GPURegionalSKU{
+						Location: fakeRegion,
+						SKUs:     []aci.GPUSKU{aci.K80, aci.P100, gpuSKU},
+					},
+				},
+			},
+		}
+
+		return http.StatusOK, manifest
+	}
+
+	provider, err := createTestProvider(aadServerMocker, aciServerMocker, nil)
+	if err != nil {
+		t.Fatalf("Creation of test provider should fail")
+	}
+
+	aciServerMocker.OnCreate = func(subscription, resourceGroup, containerGroup string, cg *aci.ContainerGroup) (int, interface{}) {
+		assert.Check(t, cg == nil, "Container group should be nil")
+
+		return http.StatusOK, cg
+	}
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: podNamespace,
+			Annotations: map[string]string{
+				gpuTypeAnnotation: string(gpuSKU),
+				"priority":        string(priority),
+			},
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				v1.Container{
+					Name: "nginx",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							"cpu":    resource.MustParse("1.981"),
+							"memory": resource.MustParse("3.49G"),
+						},
+						Limits: v1.ResourceList{
+							gpuResourceName: resource.MustParse("1"),
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := provider.CreatePod(context.Background(), pod); err == nil {
+		t.Fatal("Pod should not be created", err)
+	}
+}
+
 // Tests create pod with both resource request and limit.
 func TestCreatePodWithResourceRequestAndLimit(t *testing.T) {
 	_, aciServerMocker, provider, err := prepareMocks()


### PR DESCRIPTION
This change adds ACI spot virtual node support to virtual kubelet. 

The user can add ACI priority ('Spot' or 'Regular') to the pod definition as a part of Annotations, which will be used to direct the pod to run either on ACI Spot pool virtual nodes (for Spot priority) or ACI pool virtual nodes (for Regular priority).
This change enables users to add Spot Virtual Node to existing AKS cluster or create a new cluster which has Spot Virtual Nodes. All pods deployed on Spot Virtual Nodes will be run on ACI Spot Containers.

Validated the change by testing locally on minikube as well as by deploying on AKS cluster. Also added tests to verify that the pod is created only when valid values are passed for priority property in annotations.