### PR TITLE
test: e2e tests for CSI driver

### DIFF
--- a/e2e/fixtures/csi-driver.yml
+++ b/e2e/fixtures/csi-driver.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: vk-e2e-hpa
+  name: vk-e2e-csi-driver
   namespace: vk-test
 spec:
   containers:
@@ -12,6 +12,9 @@ spec:
       requests:
         memory: 1G
         cpu: 1
+    volumeMounts:
+      - name: azure
+        mountPath: /mnt/azure
     ports:
     - containerPort: 80
       name: http
@@ -28,6 +31,9 @@ spec:
       requests:
         memory: 1G
         cpu: 1
+    volumeMounts:
+      - name: azure
+        mountPath: /mnt/azure
   nodeSelector:
     kubernetes.io/role: agent
     beta.kubernetes.io/os: linux
@@ -36,3 +42,10 @@ spec:
   tolerations:
   - key: virtual-kubelet.io/provider
     operator: Exists
+  volumes:
+  - name: azure
+    csi:
+      driver: file.csi.azure.com
+      volumeAttributes:
+        secretName: csidriversecret  # required
+        shareName: vncsidriversharename  # required

--- a/e2e/fixtures/namespace.yml
+++ b/e2e/fixtures/namespace.yml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vk-test
+---

--- a/e2e/fixtures_test.go
+++ b/e2e/fixtures_test.go
@@ -1,13 +1,9 @@
 package e2e
 
 import (
-	"embed"
 	"os"
 	"os/exec"
 )
-
-//go:embed fixtures/*
-var fixtures embed.FS
 
 func kubectl(args ...string) *exec.Cmd {
 	cmd := exec.Command("kubectl", args...)

--- a/hack/e2e/aks.sh
+++ b/hack/e2e/aks.sh
@@ -13,7 +13,8 @@ if ! type go > /dev/null; then
   exit 1
 fi
 
-: "${RESOURCE_GROUP:=vk-aci-test-$(date +%s)}"
+: "${RANDOM_NUM:=$RANDOM}"
+: "${RESOURCE_GROUP:=vk-aci-test-$RANDOM_NUM}"
 : "${LOCATION:=westus2}"
 : "${CLUSTER_NAME:=${RESOURCE_GROUP}}"
 : "${NODE_COUNT:=1}"
@@ -28,6 +29,9 @@ fi
 : "${VNET_NAME=myAKSVNet}"
 : "${CLUSTER_SUBNET_NAME=myAKSSubnet}"
 : "${ACI_SUBNET_NAME=myACISubnet}"
+
+: "${CSI_DRIVER_STORAGE_ACCOUNT_NAME=vncsidrivers$RANDOM_NUM}"
+: "${CSI_DRIVER_SHARE_NAME=vncsidriversharename}"
 
 error() {
     echo "$@" >&2
@@ -159,5 +163,15 @@ done
 kubectl wait --for=condition=Ready --timeout=300s node "$TEST_NODE_NAME"
 
 export TEST_NODE_NAME
+
+## CSI Driver test
+az storage account create -n $CSI_DRIVER_STORAGE_ACCOUNT_NAME -g $RESOURCE_GROUP -l $LOCATION --sku Standard_LRS
+export AZURE_STORAGE_CONNECTION_STRING=$(az storage account show-connection-string -n $CSI_DRIVER_STORAGE_ACCOUNT_NAME -g $RESOURCE_GROUP -o tsv)
+
+az storage share create -n $CSI_DRIVER_SHARE_NAME --connection-string $AZURE_STORAGE_CONNECTION_STRING
+CSI_DRIVER_STORAGE_ACCOUNT_KEY=$(az storage account keys list --resource-group $RESOURCE_GROUP --account-name $CSI_DRIVER_STORAGE_ACCOUNT_NAME --query "[0].value" -o tsv)
+
+export CSI_DRIVER_STORAGE_ACCOUNT_NAME=$CSI_DRIVER_STORAGE_ACCOUNT_NAME
+export CSI_DRIVER_STORAGE_ACCOUNT_KEY=$CSI_DRIVER_STORAGE_ACCOUNT_KEY
 
 $@


### PR DESCRIPTION
In this PR:
- Update `aks.sh` script to create a storage account according to the [documentation](https://docs.microsoft.com/en-us/azure/aks/azure-files-volume#create-an-azure-file-share)
- Add test case for CSI driver 
- Remove `bytes` import as there is no need to read the file.


//@andyzhangx