### PR TITLE
feat: Remove e2e-test pipeline pull_request

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -3,8 +3,6 @@ name: e2e-tests
 on:
   push:
     branches: [master]
-  pull_request:
-    branches: [master]
     paths-ignore: [ docs/**, "**.md", "**.mdx", "**.png", "**.jpg" ]
 
 permissions:


### PR DESCRIPTION
Azure login action will not work with `pull_request` but only `pull_request_target` which has security issues and I didn't want to use it with e2e-tests. moving the pipeline to only work with push to master.