### PR TITLE
fix: Move env to environment secrets & increase test timeout

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -46,9 +46,6 @@ jobs:
     needs: export-registry
     environment: test
     env:
-      CLIENTID: 'd1464cac-2a02-4e77-a1e3-c6a9220e99b9'
-      SUBSCRIPTIONID: '076cd026-379c-4383-8bec-8835382efe90'
-      TENANT_ID: '72f988bf-86f1-41af-91ab-2d7cd011db47'
       REGISTRY: ${{ needs.export-registry.outputs.registry }}
       IMG_VERSION: "dev"
     runs-on: ubuntu-latest
@@ -87,9 +84,9 @@ jobs:
           az version
       - uses: azure/login@v1.4.5
         with:
-          client-id: ${{ env.CLIENTID }}
-          tenant-id: ${{ env.TENANT_ID }}
-          subscription-id: ${{ env.SUBSCRIPTIONID }}
+          client-id: ${{ secrets.CLIENTID }}
+          tenant-id: ${{ secrets.TENANT_ID }}
+          subscription-id: ${{ secrets.SUBSCRIPTIONID }}
 
       - name: Run e2e test
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,16 +24,12 @@ jobs:
 
   tests:
     env:
-      CLIENTID: 'd1464cac-2a02-4e77-a1e3-c6a9220e99b9'
-      SUBSCRIPTIONID: '076cd026-379c-4383-8bec-8835382efe90'
-      TENANT_ID: '72f988bf-86f1-41af-91ab-2d7cd011db47'
       ACTIVEDIRECTORYENDPOINTURL: 'https://login.microsoftonline.com'
       RESOURCEMANAGERENDPOINTURL: 'https://management.azure.com/'
       ACTIVEDIRECTORYGRAPHRESOURCEID: 'https://login.microsoftonline.com'
       SQLMANAGEMENTENDPOINTURL: 'https://management.core.windows.net:8443/'
       GALLERYENDPOINTURL: 'https://gallery.azure.com/'
       MANAGEMENTENDPOINTURL: 'https://manage.windowsazure.com/'
-      OMSWORKSPACEID: '4f211d5f-39a4-4a52-a3bb-b49cf4fc7017'
       CLIENTSECRET: ${{ secrets.CLIENT_SECRET }}
       WORKSPACEKEY: ${{ secrets.OMS_WORKSPACE_KEY }}
 
@@ -61,9 +57,9 @@ jobs:
 
       - name: Run unit tests & Generate coverage
         env:
-          clientId: ${{ env.CLIENTID  }}
-          subscriptionId: ${{ env.SUBSCRIPTIONID  }}
-          tenantId: ${{ env.TENANT_ID }}
+          clientId: ${{ secrets.CLIENTID  }}
+          subscriptionId: ${{ secrets.SUBSCRIPTIONID  }}
+          tenantId: ${{ secrets.TENANT_ID }}
           activeDirectoryEndpointUrl: ${{ env.ACTIVEDIRECTORYENDPOINTURL  }}
           resourceManagerEndpointUrl: ${{ env.RESOURCEMANAGERENDPOINTURL  }}
           activeDirectoryGraphResourceId: ${{ env.ACTIVEDIRECTORYGRAPHRESOURCEID  }}
@@ -71,7 +67,7 @@ jobs:
           galleryEndpointUrl: ${{ env.GALLERYENDPOINTURL  }}
           managementEndpointUrl: ${{ env.MANAGEMENTENDPOINTURL  }}
           clientSecret: ${{ secrets.CLIENT_SECRET }}
-          omsworkspaceID: ${{ env.OMSWORKSPACEID  }}
+          omsworkspaceID: ${{ secrets.OMSWORKSPACEID  }}
           omsworkspaceKey: ${{ secrets.OMS_WORKSPACE_KEY }}
         run: |
            make testauth test

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ test:
 
 .PHONY: e2e-test
 e2e-test:
-	IMG_URL=$(REGISTRY) IMG_REPO=$(IMG_NAME) IMG_TAG=$(IMG_TAG) $(AKS_E2E) go test -v ./e2e
+	IMG_URL=$(REGISTRY) IMG_REPO=$(IMG_NAME) IMG_TAG=$(IMG_TAG) $(AKS_E2E) go test -timeout 30m -v ./e2e
 
 .PHONY: vet
 vet:


### PR DESCRIPTION
- Move subscription, clientID, and tenantID to be environment secrets.
- Increase e2e test timeout
