### PR TITLE
ci: Move e2e images to be in a temp ACR instead of GH packages

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -9,7 +9,7 @@ on:
       - "charts/**"
   create:
     # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
+    tags: [ 'v*.*.*.*' ]
 
 permissions:
   contents: write

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -9,9 +9,8 @@ on:
     paths-ignore: [ docs/**, "**.md", "**.mdx", "**.png", "**.jpg" ]
 
 permissions:
-  id-token: write
-  contents: read
-  packages: write
+   id-token: write
+   contents: read
 
 env:
   REGISTRY: ghcr.io
@@ -57,29 +56,23 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Shorten SHA
+        id: vars
+        run: echo "::set-output name=pr_sha_short::$(git rev-parse --short ${{ github.event.pull_request.head.sha }} )"
 
       - name: Set e2e Cluster Name
         run: |
-          rand=$RANDOM
-          echo "CLUSTER_NAME=vk-aci-test-${rand}" >> $GITHUB_ENV
-
-      - name: Login to ${{ env.REGISTRY }}
-        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build image
-        run: |
-          OUTPUT_TYPE=type=registry make docker-build-image
-        env:
-          VERSION: ${{ env.E2E_IMG_TAG}}
+          echo "CLUSTER_NAME=vk-aci-test-${{ steps.vars.outputs.pr_sha_short }}" >> $GITHUB_ENV
 
       - name: Install Azure CLI latest
         run: |
           curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
           az version
+
       - uses: azure/login@v1.4.5
         with:
           client-id: ${{ secrets.CLIENTID }}
@@ -88,21 +81,17 @@ jobs:
 
       - name: Run e2e test
         run: |
-          make e2e-test
+          OUTPUT_TYPE=type=registry make e2e-test
         env:
           REGISTRY: ${{ env.REGISTRY}}
           E2E_REGION: ${{ secrets.E2E_REGION}}
           CLUSTER_NAME: ${{ env.CLUSTER_NAME }}
           VERSION: ${{ env.E2E_IMG_TAG}}
+          E2E_TARGET: "pr"
+          PR_COMMIT_SHA: ${{ steps.vars.outputs.pr_sha_short }}
 
       - name: Cleanup e2e resources
         if: ${{ always() }}
         run: |
           set +e
           az group delete --name "${{ env.CLUSTER_NAME }}" --yes --no-wait || true
-
-      - uses: actions/delete-package-versions@v3
-        if: ${{ always() }}
-        with:
-          package-name: 'virtual-kubelet'
-          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,34 +1,23 @@
-name: create_release
+name: publish_images
+
 on:
   create:
     # Publish semver tags as releases.
     tags: [ 'v*.*.*.*' ]
 
 permissions:
-  contents: write
+  contents: read
   packages: write
 
 env:
   REGISTRY: ghcr.io
+  IMAGE_NAME: virtual-kubelet
 
 jobs:
-  create-release:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Goreleaser
-        uses: goreleaser/goreleaser-action@v2.9.1
-        with:
-          version: latest
-          args: release --rm-dist --timeout 60m --debug
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   export-registry:
     runs-on: ubuntu-20.04
+    needs: detect-noop
+    if: needs.detect-noop.outputs.noop != 'true'
     outputs:
       registry: ${{ steps.export.outputs.registry }}
     steps:
@@ -47,20 +36,15 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-      - name: Login to ghcr.io
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      - name: Login to ${{ env.REGISTRY }}
+        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set env
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-      - name: Set Image tag
-        run: |
-          ver=${{ env.RELEASE_VERSION}}
-          echo "IMG_TAG=${ver#"v"}" >> $GITHUB_ENV
+
       - name: Build image
         run: |
           OUTPUT_TYPE=type=registry make docker-build-image
         env:
-          VERSION: ${{ env.IMG_TAG }}
+          VERSION: ${{ env.E2E_IMG_TAG}}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,8 +47,9 @@ jobs:
         if: github.event_name == 'pull_request_target'
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
       - name: Checkout
         if: github.event_name != 'pull_request_target'
         uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ TEST_LOGANALYTICS_JSON ?= $(TEST_CREDENTIALS_DIR)/loganalytics.json
 export TEST_CREDENTIALS_JSON TEST_LOGANALYTICS_JSON
 
 IMG_NAME ?= virtual-kubelet
-IMG_REPO ?= $(REGISTRY)/$(IMG_NAME)
+IMAGE ?= $(REGISTRY)/$(IMG_NAME)
 LOCATION := $(E2E_REGION)
 E2E_CLUSTER_NAME := $(CLUSTER_NAME)
 
@@ -59,7 +59,7 @@ docker-build-image: docker-buildx-builder
 		--output=$(OUTPUT_TYPE) \
 		--platform="$(BUILDPLATFORM)" \
 		--pull \
-		--tag $(IMG_REPO):$(IMG_TAG) .
+		--tag $(IMAGE):$(IMG_TAG) .
 
 .PHONY: build
 build: bin/virtual-kubelet
@@ -80,7 +80,7 @@ test:
 
 .PHONY: e2e-test
 e2e-test:
-	IMG_URL=$(REGISTRY) IMG_REPO=$(IMG_NAME) IMG_TAG=$(IMG_TAG) LOCATION=$(LOCATION) RESOURCE_GROUP=$(E2E_CLUSTER_NAME) $(AKS_E2E_SCRIPT) go test -timeout 30m -v ./e2e
+	PR_RAND=$(PR_COMMIT_SHA) E2E_TARGET=$(E2E_TARGET) IMG_URL=$(REGISTRY) IMG_REPO=$(IMG_NAME) IMG_TAG=$(IMG_TAG) LOCATION=$(LOCATION) RESOURCE_GROUP=$(E2E_CLUSTER_NAME) $(AKS_E2E_SCRIPT) go test -timeout 30m -v ./e2e
 
 .PHONY: vet
 vet:

--- a/hack/e2e/aks.sh
+++ b/hack/e2e/aks.sh
@@ -13,7 +13,12 @@ if ! type go > /dev/null; then
   exit 1
 fi
 
-: "${RANDOM_NUM:=$RANDOM}"
+: "${RANDOM_NUM:=${PR_RAND}}"
+
+if [ "$PR_RAND" = "" ]; then
+    RANDOM_NUM=$RANDOM
+fi
+
 : "${RESOURCE_GROUP:=vk-aci-test-$RANDOM_NUM}"
 : "${LOCATION:=westus2}"
 : "${CLUSTER_NAME:=${RESOURCE_GROUP}}"
@@ -29,7 +34,7 @@ fi
 : "${VNET_NAME=myAKSVNet}"
 : "${CLUSTER_SUBNET_NAME=myAKSSubnet}"
 : "${ACI_SUBNET_NAME=myACISubnet}"
-
+: "${ACR_NAME=vkacr$RANDOM_NUM}"
 : "${CSI_DRIVER_STORAGE_ACCOUNT_NAME=vkcsidrivers$RANDOM_NUM}"
 : "${CSI_DRIVER_SHARE_NAME=vncsidriversharename}"
 
@@ -68,6 +73,16 @@ fi
 
 az group create --name "$RESOURCE_GROUP" --location "$LOCATION"
 
+if [ "$E2E_TARGET" = "pr" ]; then
+  az acr create --resource-group "$RESOURCE_GROUP" \
+    --name "$ACR_NAME" --sku Basic
+
+  az acr login --name "$ACR_NAME"
+  IMG_URL=$ACR_NAME.azurecr.io
+  IMG_REPO="virtual-kubelet"
+  OUTPUT_TYPE=type=registry IMG_TAG=$IMG_TAG  IMAGE=$ACR_NAME.azurecr.io/$IMG_REPO make docker-build-image
+
+fi
 
 KUBE_DNS_IP=10.0.0.10
 
@@ -95,6 +110,23 @@ node_identity="$(az identity create --name "${RESOURCE_GROUP}-node-identity" --r
 
 node_identity_id="$(az identity show --name ${RESOURCE_GROUP}-node-identity --resource-group ${RESOURCE_GROUP} --query id -o tsv)"
 cluster_identity_id="$(az identity show --name ${RESOURCE_GROUP}-aks-identity --resource-group ${RESOURCE_GROUP} --query id -o tsv)"
+
+if [ "$E2E_TARGET" = "pr" ]; then
+az aks create \
+    -g "$RESOURCE_GROUP" \
+    -l "$LOCATION" \
+    -c "$NODE_COUNT" \
+    --node-vm-size standard_d8_v3 \
+    -n "$CLUSTER_NAME" \
+    --network-plugin azure \
+    --vnet-subnet-id "$aks_subnet_id" \
+    --dns-service-ip "$KUBE_DNS_IP" \
+    --assign-kubelet-identity "$node_identity_id" \
+    --assign-identity "$cluster_identity_id" \
+    --generate-ssh-keys \
+    --attach-acr "$ACR_NAME"
+fi
+
 az aks create \
     -g "$RESOURCE_GROUP" \
     -l "$LOCATION" \


### PR DESCRIPTION
In this PR:
- Move e2e images to be in ACR instead of GH packages. (Fixes #282   #283 )
- Fix checkout action to be for the current 
-  Create a separate workflow to publish a new image with the new releases.
- Increase `SemVer` to include (v*.*.*.*)