### PR TITLE
ci: Remove dash from cluster name

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Set e2e Cluster Name
         run: |
-          echo "CLUSTER_NAME=vk-aci-test-${{ steps.vars.outputs.pr_sha_short }}" >> $GITHUB_ENV
+          echo "CLUSTER_NAME=vk-aci-test${{ steps.vars.outputs.pr_sha_short }}" >> $GITHUB_ENV
 
       - name: Install Azure CLI latest
         run: |


### PR DESCRIPTION
In the case of running e2e-test workflow for master, the pr_sha will be empty. the [aks name](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftcontainerservice) can't end with `-`.