### PR TITLE
chore: Upgrade workflows to go 1.18

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -14,6 +14,8 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
+  # Common versions
+  GO_VERSION: '1.18'
 
 jobs:
   detect-noop:
@@ -49,10 +51,10 @@ jobs:
       E2E_IMG_TAG:  "e2e-ci"
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go
+      - name:  Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ secrets.GO_VERSION  }}
+          go-version: ${{ env.GO_VERSION  }}
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,10 @@ on:
     branches: [master]
     paths-ignore: [ docs/**, "**.md", "**.mdx", "**.png", "**.jpg" ]
 
+env:
+  # Common versions
+  GO_VERSION: '1.18'
+
 jobs:
   detect-noop:
     runs-on: ubuntu-latest
@@ -38,10 +42,10 @@ jobs:
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
     steps:
-      - name: Set up Go
+      - name:  Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ secrets.GO_VERSION  }}
+          go-version: ${{ env.GO_VERSION  }}
 
       - name: Check out code into the Go module directory
         if: github.event_name == 'pull_request_target'
@@ -49,12 +53,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-
-      - name: Checkout
-        if: github.event_name != 'pull_request_target'
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Run unit tests & Generate coverage
         env:


### PR DESCRIPTION
- Upgrade `tests` and `e2e-tests` workflow to use go `1.18`
- Remove duplicate `checkout` step in tests workflow