### PR TITLE
chore: Migrate ACI log analytics to use Azure SDK

### DIFF
--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -1,0 +1,43 @@
+package analytics
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+
+	azaci "github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2021-10-01/containerinstance"
+)
+
+// NewContainerGroupDiagnostics creates a container group diagnostics object
+func NewContainerGroupDiagnostics(logAnalyticsID, logAnalyticsKey string) (*azaci.ContainerGroupDiagnostics, error) {
+
+	if logAnalyticsID == "" || logAnalyticsKey == "" {
+		return nil, errors.New("log Analytics configuration requires both the workspace ID and Key")
+	}
+
+	return &azaci.ContainerGroupDiagnostics{
+		LogAnalytics: &azaci.LogAnalytics{
+			WorkspaceID:  &logAnalyticsID,
+			WorkspaceKey: &logAnalyticsKey,
+		},
+	}, nil
+}
+
+// NewContainerGroupDiagnosticsFromFile creates a container group diagnostics object from the specified file
+func NewContainerGroupDiagnosticsFromFile(filepath string) (*azaci.ContainerGroupDiagnostics, error) {
+
+	analyticsdata, err := ioutil.ReadFile(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("Reading Log Analytics Auth file %q failed: %v", filepath, err)
+	}
+	// Unmarshal the log analytics file.
+	var law azaci.LogAnalytics
+	if err := json.Unmarshal(analyticsdata, &law); err != nil {
+		return nil, err
+	}
+
+	return &azaci.ContainerGroupDiagnostics{
+		LogAnalytics: &law,
+	}, nil
+}

--- a/pkg/analytics/analytics_test.go
+++ b/pkg/analytics/analytics_test.go
@@ -1,0 +1,38 @@
+package analytics
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestLogAnalyticsFileParsingSuccess(t *testing.T) {
+	diagnostics, err := NewContainerGroupDiagnosticsFromFile(os.Getenv("LOG_ANALYTICS_AUTH_LOCATION"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diagnostics == nil || diagnostics.LogAnalytics == nil {
+		t.Fatalf("Unexpected nil diagnostics. Log Analytics file not parsed correctly")
+	}
+
+	if *diagnostics.LogAnalytics.WorkspaceID == "" || *diagnostics.LogAnalytics.WorkspaceKey == "" {
+		t.Fatalf("Unexpected empty analytics authentication credentials. Log Analytics file not parsed correctly")
+	}
+}
+
+func TestLogAnalyticsFileParsingFailure(t *testing.T) {
+	tempFile, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = NewContainerGroupDiagnosticsFromFile(tempFile.Name())
+
+	// Cleaup
+	tempFile.Close()
+	os.Remove(tempFile.Name())
+
+	if err == nil {
+		t.Fatalf("Expected parsing an empty Log Analytics auth file to fail, but there were no errors")
+	}
+}


### PR DESCRIPTION
Migrate from the custom SDK to the official Azure container instance SDK

old files:
- https://github.com/virtual-kubelet/azure-aci/blob/master/client/aci/analytics.go
- https://github.com/virtual-kubelet/azure-aci/blob/master/client/aci/analytics_test.go