### PR TITLE
fix: Add explicit name for the CG properties wrapper to fix json issue

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -25,7 +25,7 @@ type ContainerGroupWrapper struct {
 	// Identity - The identity of the container group, if configured.
 	Identity *azaci.ContainerGroupIdentity `json:"identity,omitempty"`
 	// ContainerGroupProperties - The container group properties
-	*ContainerGroupPropertiesWrapper `json:"properties,omitempty"`
+	ContainerGroupPropertiesWrapper *ContainerGroupPropertiesWrapper `json:"properties,omitempty"`
 	// ID - READ-ONLY; The resource id.
 	ID *string `json:"id,omitempty"`
 	// Name - READ-ONLY; The resource name.
@@ -86,43 +86,41 @@ func (c *ContainerGroupsClientWrapper) createOrUpdatePreparerWrapper(ctx context
 // MarshalJSON is the custom marshaler for ContainerGroupProperties.
 func (cg ContainerGroupPropertiesWrapper) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
-	if cg.ContainerGroupProperties != nil {
-		if cg.ContainerGroupProperties.Containers != nil {
-			objectMap["containers"] = cg.ContainerGroupProperties.Containers
-		}
-		if cg.ContainerGroupProperties.ImageRegistryCredentials != nil {
-			objectMap["imageRegistryCredentials"] = cg.ContainerGroupProperties.ImageRegistryCredentials
-		}
-		if cg.ContainerGroupProperties.RestartPolicy != "" {
-			objectMap["restartPolicy"] = cg.ContainerGroupProperties.RestartPolicy
-		}
-		if cg.ContainerGroupProperties.IPAddress != nil {
-			objectMap["ipAddress"] = cg.ContainerGroupProperties.IPAddress
-		}
-		if cg.ContainerGroupProperties.OsType != "" {
-			objectMap["osType"] = cg.ContainerGroupProperties.OsType
-		}
-		if cg.ContainerGroupProperties.Volumes != nil {
-			objectMap["volumes"] = cg.ContainerGroupProperties.Volumes
-		}
-		if cg.ContainerGroupProperties.Diagnostics != nil {
-			objectMap["diagnostics"] = cg.ContainerGroupProperties.Diagnostics
-		}
-		if cg.ContainerGroupProperties.SubnetIds != nil {
-			objectMap["subnetIds"] = cg.ContainerGroupProperties.SubnetIds
-		}
-		if cg.ContainerGroupProperties.DNSConfig != nil {
-			objectMap["dnsConfig"] = cg.ContainerGroupProperties.DNSConfig
-		}
-		if cg.ContainerGroupProperties.Sku != "" {
-			objectMap["sku"] = cg.ContainerGroupProperties.Sku
-		}
-		if cg.ContainerGroupProperties.EncryptionProperties != nil {
-			objectMap["encryptionProperties"] = cg.ContainerGroupProperties.EncryptionProperties
-		}
-		if cg.ContainerGroupProperties.InitContainers != nil {
-			objectMap["initContainers"] = cg.ContainerGroupProperties.InitContainers
-		}
+	if cg.ContainerGroupProperties.Containers != nil {
+		objectMap["containers"] = cg.ContainerGroupProperties.Containers
+	}
+	if cg.ContainerGroupProperties.ImageRegistryCredentials != nil {
+		objectMap["imageRegistryCredentials"] = cg.ContainerGroupProperties.ImageRegistryCredentials
+	}
+	if cg.ContainerGroupProperties.RestartPolicy != "" {
+		objectMap["restartPolicy"] = cg.ContainerGroupProperties.RestartPolicy
+	}
+	if cg.ContainerGroupProperties.IPAddress != nil {
+		objectMap["ipAddress"] = cg.ContainerGroupProperties.IPAddress
+	}
+	if cg.ContainerGroupProperties.OsType != "" {
+		objectMap["osType"] = cg.ContainerGroupProperties.OsType
+	}
+	if cg.ContainerGroupProperties.Volumes != nil {
+		objectMap["volumes"] = cg.ContainerGroupProperties.Volumes
+	}
+	if cg.ContainerGroupProperties.Diagnostics != nil {
+		objectMap["diagnostics"] = cg.ContainerGroupProperties.Diagnostics
+	}
+	if cg.ContainerGroupProperties.SubnetIds != nil {
+		objectMap["subnetIds"] = cg.ContainerGroupProperties.SubnetIds
+	}
+	if cg.ContainerGroupProperties.DNSConfig != nil {
+		objectMap["dnsConfig"] = cg.ContainerGroupProperties.DNSConfig
+	}
+	if cg.ContainerGroupProperties.Sku != "" {
+		objectMap["sku"] = cg.ContainerGroupProperties.Sku
+	}
+	if cg.ContainerGroupProperties.EncryptionProperties != nil {
+		objectMap["encryptionProperties"] = cg.ContainerGroupProperties.EncryptionProperties
+	}
+	if cg.ContainerGroupProperties.InitContainers != nil {
+		objectMap["initContainers"] = cg.ContainerGroupProperties.InitContainers
 	}
 	if cg.Extensions != nil {
 		objectMap["extensions"] = cg.Extensions

--- a/pkg/provider/aci_test.go
+++ b/pkg/provider/aci_test.go
@@ -31,7 +31,7 @@ import (
 const (
 	fakeResourceGroup = "vk-rg"
 	fakeNodeName      = "vk"
-	fakeRegion        = "westus"
+	fakeRegion        = "westus2"
 )
 
 var (
@@ -111,7 +111,7 @@ func TestCreatePodWithoutResourceSpec(t *testing.T) {
 	aciMocks := createNewACIMock()
 
 	aciMocks.MockCreateContainerGroup = func(ctx context.Context, resourceGroup, podNS, podName string, cg *client.ContainerGroupWrapper) error {
-		containers := *cg.ContainerGroupProperties.Containers
+		containers := *cg.ContainerGroupPropertiesWrapper.ContainerGroupProperties.Containers
 		assert.Check(t, cg != nil, "Container group is nil")
 		assert.Check(t, containers != nil, "Containers should not be nil")
 		assert.Check(t, is.Equal(1, len(containers)), "1 Container is expected")
@@ -152,7 +152,7 @@ func TestCreatePodWithResourceRequestOnly(t *testing.T) {
 
 	aciMocks := createNewACIMock()
 	aciMocks.MockCreateContainerGroup = func(ctx context.Context, resourceGroup, podNS, podName string, cg *client.ContainerGroupWrapper) error {
-		containers := *cg.ContainerGroupProperties.Containers
+		containers := *cg.ContainerGroupPropertiesWrapper.ContainerGroupProperties.Containers
 		assert.Check(t, cg != nil, "container group is nil")
 		assert.Check(t, containers != nil, "container should not be nil")
 		assert.Check(t, is.Equal(1, len(containers)), "only container is expected")
@@ -201,14 +201,13 @@ func TestCreatePodWithResourceRequestOnly(t *testing.T) {
 
 // Tests create pod with default GPU SKU.
 func TestCreatePodWithGPU(t *testing.T) {
-
 	podName := "pod-" + uuid.New().String()
 	podNamespace := "ns-" + uuid.New().String()
 
 	aciMocks := createNewACIMock()
 
 	aciMocks.MockCreateContainerGroup = func(ctx context.Context, resourceGroup, podNS, podName string, cg *client.ContainerGroupWrapper) error {
-		containers := *cg.ContainerGroupProperties.Containers
+		containers := *cg.ContainerGroupPropertiesWrapper.ContainerGroupProperties.Containers
 		assert.Check(t, containers != nil, "Containers should not be nil")
 		assert.Check(t, is.Equal(1, len(containers)), "1 Container is expected")
 		assert.Check(t, is.Equal("nginx", *(containers[0]).Name), "Container nginx is expected")
@@ -262,7 +261,7 @@ func TestCreatePodWithGPUSKU(t *testing.T) {
 
 	aciMocks := createNewACIMock()
 	aciMocks.MockCreateContainerGroup = func(ctx context.Context, resourceGroup, podNS, podName string, cg *client.ContainerGroupWrapper) error {
-		containers := *cg.ContainerGroupProperties.Containers
+		containers := *cg.ContainerGroupPropertiesWrapper.ContainerGroupProperties.Containers
 		assert.Check(t, cg != nil, "Container group is nil")
 		assert.Check(t, containers != nil, "Containers should not be nil")
 		assert.Check(t, is.Equal(1, len(containers)), "1 Container is expected")
@@ -322,7 +321,7 @@ func TestCreatePodWithResourceRequestAndLimit(t *testing.T) {
 	aciMocks := createNewACIMock()
 
 	aciMocks.MockCreateContainerGroup = func(ctx context.Context, resourceGroup, podNS, podName string, cg *client.ContainerGroupWrapper) error {
-		containers := *cg.ContainerGroupProperties.Containers
+		containers := *cg.ContainerGroupPropertiesWrapper.ContainerGroupProperties.Containers
 		assert.Check(t, cg != nil, "Container group is nil")
 		assert.Check(t, containers != nil, "Containers should not be nil")
 		assert.Check(t, is.Equal(1, len(containers)), "1 Container is expected")
@@ -970,14 +969,16 @@ func TestCreatePodWithNamedLivenessProbe(t *testing.T) {
 	aciMocks := createNewACIMock()
 
 	aciMocks.MockCreateContainerGroup = func(ctx context.Context, resourceGroup, podNS, podName string, cg *client.ContainerGroupWrapper) error {
-		assert.Check(t, (*cg.ContainerGroupProperties.Containers)[0].LivenessProbe != nil, "Liveness probe expected")
-		assert.Check(t, is.Equal(int32(10), *(*cg.ContainerGroupProperties.Containers)[0].LivenessProbe.InitialDelaySeconds), "Initial Probe Delay doesn't match")
-		assert.Check(t, is.Equal(int32(5), *(*cg.ContainerGroupProperties.Containers)[0].LivenessProbe.PeriodSeconds), "Probe Period doesn't match")
-		assert.Check(t, is.Equal(int32(60), *(*cg.ContainerGroupProperties.Containers)[0].LivenessProbe.TimeoutSeconds), "Probe Timeout doesn't match")
-		assert.Check(t, is.Equal(int32(3), *(*cg.ContainerGroupProperties.Containers)[0].LivenessProbe.SuccessThreshold), "Probe Success Threshold doesn't match")
-		assert.Check(t, is.Equal(int32(5), *(*cg.ContainerGroupProperties.Containers)[0].LivenessProbe.FailureThreshold), "Probe Failure Threshold doesn't match")
-		assert.Check(t, (*cg.ContainerGroupProperties.Containers)[0].LivenessProbe.HTTPGet != nil, "Expected an HTTP Get Probe")
-		assert.Check(t, is.Equal(int32(8080), *(*cg.ContainerGroupProperties.Containers)[0].LivenessProbe.HTTPGet.Port), "Expected Port to be 8080")
+		containers := *cg.ContainerGroupPropertiesWrapper.ContainerGroupProperties.Containers
+
+		assert.Check(t, (containers)[0].LivenessProbe != nil, "Liveness probe expected")
+		assert.Check(t, is.Equal(int32(10), *(containers)[0].LivenessProbe.InitialDelaySeconds), "Initial Probe Delay doesn't match")
+		assert.Check(t, is.Equal(int32(5), *(containers)[0].LivenessProbe.PeriodSeconds), "Probe Period doesn't match")
+		assert.Check(t, is.Equal(int32(60), *(containers)[0].LivenessProbe.TimeoutSeconds), "Probe Timeout doesn't match")
+		assert.Check(t, is.Equal(int32(3), *(containers)[0].LivenessProbe.SuccessThreshold), "Probe Success Threshold doesn't match")
+		assert.Check(t, is.Equal(int32(5), *(containers)[0].LivenessProbe.FailureThreshold), "Probe Failure Threshold doesn't match")
+		assert.Check(t, (*cg.ContainerGroupPropertiesWrapper.ContainerGroupProperties.Containers)[0].LivenessProbe.HTTPGet != nil, "Expected an HTTP Get Probe")
+		assert.Check(t, is.Equal(int32(8080), *(containers)[0].LivenessProbe.HTTPGet.Port), "Expected Port to be 8080")
 		return nil
 	}
 
@@ -1030,7 +1031,7 @@ func TestCreatePodWithLivenessProbe(t *testing.T) {
 
 	aciMocks := createNewACIMock()
 	aciMocks.MockCreateContainerGroup = func(ctx context.Context, resourceGroup, podNS, podName string, cg *client.ContainerGroupWrapper) error {
-		containers := *cg.ContainerGroupProperties.Containers
+		containers := *cg.ContainerGroupPropertiesWrapper.ContainerGroupProperties.Containers
 		assert.Check(t, cg != nil, "Container group is nil")
 		assert.Check(t, containers != nil, "Containers should not be nil")
 		assert.Check(t, is.Equal(1, len(containers)), "1 Container is expected")
@@ -1090,7 +1091,7 @@ func TestCreatePodWithReadinessProbe(t *testing.T) {
 	aciMocks := createNewACIMock()
 
 	aciMocks.MockCreateContainerGroup = func(ctx context.Context, resourceGroup, podNS, podName string, cg *client.ContainerGroupWrapper) error {
-		containers := *cg.ContainerGroupProperties.Containers
+		containers := *cg.ContainerGroupPropertiesWrapper.ContainerGroupProperties.Containers
 		assert.Check(t, cg != nil, "Container group is nil")
 		assert.Check(t, containers != nil, "Containers should not be nil")
 		assert.Check(t, is.Equal(1, len(containers)), "1 Container is expected")

--- a/pkg/provider/aci_volumes_test.go
+++ b/pkg/provider/aci_volumes_test.go
@@ -36,16 +36,16 @@ func TestCreatedPodWithAzureFilesVolume(t *testing.T) {
 
 	aciMocks := createNewACIMock()
 	aciMocks.MockCreateContainerGroup = func(ctx context.Context, resourceGroup, podNS, podName string, cg *client.ContainerGroupWrapper) error {
-		containers := *cg.ContainerGroupProperties.Containers
+		containers := *cg.ContainerGroupPropertiesWrapper.ContainerGroupProperties.Containers
 		assert.Check(t, cg != nil, "Container group is nil")
 		assert.Check(t, containers != nil, "Containers should not be nil")
-		assert.Check(t, is.Equal(1, len(*cg.ContainerGroupPropertiesWrapper.ContainerGroupProperties.Containers)), "1 Container is expected")
-		assert.Check(t, is.Equal("nginx", *(*cg.ContainerGroupPropertiesWrapper.ContainerGroupProperties.Containers)[0].Name), "Container nginx is expected")
-		assert.Check(t, is.Equal(3, len(*cg.ContainerGroupProperties.Volumes)), "volume count not match")
-		assert.Check(t, is.Equal(azureFileVolumeName1, *(*cg.ContainerGroupProperties.Volumes)[1].Name), "volume name is not matched")
-		assert.Check(t, is.Equal(fakeShareName1, *(*cg.ContainerGroupProperties.Volumes)[1].AzureFile.ShareName), "volume share name is not matched")
-		assert.Check(t, is.Equal(azureFileVolumeName2, *(*cg.ContainerGroupProperties.Volumes)[2].Name), "volume name is not matched")
-		assert.Check(t, is.Equal(fakeShareName2, *(*cg.ContainerGroupProperties.Volumes)[2].AzureFile.ShareName), "volume share name is not matched")
+		assert.Check(t, is.Equal(1, len(containers)), "1 Container is expected")
+		assert.Check(t, is.Equal("nginx", *(containers)[0].Name), "Container nginx is expected")
+		assert.Check(t, is.Equal(3, len(*cg.ContainerGroupPropertiesWrapper.ContainerGroupProperties.Volumes)), "volume count not match")
+		assert.Check(t, is.Equal(azureFileVolumeName1, *(*cg.ContainerGroupPropertiesWrapper.ContainerGroupProperties.Volumes)[1].Name), "volume name is not matched")
+		assert.Check(t, is.Equal(fakeShareName1, *(*cg.ContainerGroupPropertiesWrapper.ContainerGroupProperties.Volumes)[1].AzureFile.ShareName), "volume share name is not matched")
+		assert.Check(t, is.Equal(azureFileVolumeName2, *(*cg.ContainerGroupPropertiesWrapper.ContainerGroupProperties.Volumes)[2].Name), "volume name is not matched")
+		assert.Check(t, is.Equal(fakeShareName2, *(*cg.ContainerGroupPropertiesWrapper.ContainerGroupProperties.Volumes)[2].AzureFile.ShareName), "volume share name is not matched")
 
 		return nil
 	}
@@ -240,14 +240,14 @@ func TestCreatePodWithProjectedVolume(t *testing.T) {
 
 	encodedSecretVal := base64.StdEncoding.EncodeToString([]byte("fake-ca-data"))
 	aciMocks.MockCreateContainerGroup = func(ctx context.Context, resourceGroup, podNS, podName string, cg *client.ContainerGroupWrapper) error {
-		containers := *cg.ContainerGroupProperties.Containers
-		volumes := *cg.ContainerGroupProperties.Volumes
-		certVal := (*cg.ContainerGroupProperties.Volumes)[2].Secret["ca.crt"]
+		containers := *cg.ContainerGroupPropertiesWrapper.ContainerGroupProperties.Containers
+		volumes := *cg.ContainerGroupPropertiesWrapper.ContainerGroupProperties.Volumes
+		certVal := (*cg.ContainerGroupPropertiesWrapper.ContainerGroupProperties.Volumes)[2].Secret["ca.crt"]
 		assert.Check(t, cg != nil, "Container group is nil")
 		assert.Check(t, containers != nil, "Containers should not be nil")
 		assert.Check(t, is.Equal(1, len(containers)), "1 Container is expected")
 		assert.Check(t, is.Equal("nginx", *(containers[0]).Name), "Container nginx is expected")
-		assert.Check(t, is.Equal(3, len(*cg.ContainerGroupProperties.Volumes)), "volume count not match")
+		assert.Check(t, is.Equal(3, len(volumes)), "volume count not match")
 		assert.Check(t, is.Equal(projectedVolumeName, *volumes[2].Name), "volume name doesn't match")
 		assert.Check(t, is.Equal(encodedSecretVal, *certVal), "configmap data doesn't match")
 
@@ -396,12 +396,12 @@ func TestCreatePodWithCSIVolume(t *testing.T) {
 
 	aciMocks := createNewACIMock()
 	aciMocks.MockCreateContainerGroup = func(ctx context.Context, resourceGroup, podNS, podName string, cg *client.ContainerGroupWrapper) error {
-		containers := *cg.ContainerGroupProperties.Containers
+		containers := *cg.ContainerGroupPropertiesWrapper.ContainerGroupProperties.Containers
 		assert.Check(t, cg != nil, "Container group is nil")
 		assert.Check(t, containers != nil, "Containers should not be nil")
 		assert.Check(t, is.Equal(1, len(containers)), "1 Container is expected")
 		assert.Check(t, is.Equal("nginx", *(containers[0]).Name), "Container nginx is expected")
-		assert.Check(t, is.Equal(2, len(*cg.ContainerGroupProperties.Volumes)), "volume count not match")
+		assert.Check(t, is.Equal(2, len(*cg.ContainerGroupPropertiesWrapper.ContainerGroupProperties.Volumes)), "volume count not match")
 
 		return nil
 	}


### PR DESCRIPTION
Add an explicit name for the CG properties wrapper to fix `MarshalJson` issue