### PR TITLE
Added support for providing Log Analytics Id and Key, and Custom columns in the pod spec

### DIFF
--- a/charts/virtual-kubelet/templates/deployment.yaml
+++ b/charts/virtual-kubelet/templates/deployment.yaml
@@ -29,6 +29,8 @@ spec:
           value: /etc/virtual-kubelet/cert.pem
         - name: APISERVER_KEY_LOCATION
           value: /etc/virtual-kubelet/key.pem
+        - name: APISERVER_CA_CERT_LOCATION
+          value: /etc/kubernetes/certs/ca.crt
         - name: VKUBELET_POD_IP
           valueFrom:
             fieldRef:

--- a/client/aci/types.go
+++ b/client/aci/types.go
@@ -453,8 +453,9 @@ type ExtensionType string
 
 // Supported extension types
 const (
-	ExtensionTypeKubeProxy       ExtensionType = "kube-proxy"
-	ExtensionTypeRealtimeMetrics ExtensionType = "realtime-metrics"
+	ExtensionTypeKubeProxy        ExtensionType = "kube-proxy"
+	ExtensionTypeRealtimeMetrics  ExtensionType = "realtime-metrics"
+	ExtensionTypeFirstPartyLogger ExtensionType = "firstpartylogger"
 )
 
 // ExtensionVersion is an enum type for defining supported extension versions
@@ -462,7 +463,8 @@ type ExtensionVersion string
 
 // Supported extension version
 const (
-	ExtensionVersion1_0 ExtensionVersion = "1.0"
+	ExtensionVersion1_0            ExtensionVersion = "1.0"
+	FirstPartyLoggerDefaultVersion ExtensionVersion = ""
 )
 
 // Supported kube-proxy extension constants


### PR DESCRIPTION
1. Added a CA cert env var so that we can see logs through kubectl for a pod running in ACI.
2. Added a new extension for CustomLogger so that logs can be seen in a Log Analytics workspace for a CG running in ACI through the virtual kubelet. The LA Id and Key is provided through the annotations in the pod spec.
3. Added support for showing custom columns in Log Analytics workspace for a CG running in ACI through the virtual kubelet. These custom columns (and their values) are also provided in the pod spec as an annotation which are then parsed and supplied to the custom logger extension. These columns (and their values) are visible in ContainerAppConsoleLogs_CL table in the Log Analytics workspace.