### PR TITLE
fix: Remove all but the coreDNS ip from resolv.conf

### DIFF
--- a/charts/virtual-kubelet/values.yaml
+++ b/charts/virtual-kubelet/values.yaml
@@ -57,7 +57,7 @@ providers:
       # clusterCidr defaults to 10.240.0.0/16 if not specified
       clusterCidr:
       # kubeDnsIp defaults to 10.0.0.10 if not specified
-      kubeDnsIp:
+      kubeDnsIp: 10.0.0.10
 
 provider: azure
 


### PR DESCRIPTION
- Pass default kube_DNS via helm instead of static value in the code.
- Update `formDNSSearchFitsLimits` to match k8s kubelet.
- Pass `ctx` instead of `context.TODO`.
- Remove azureIP to have only one IP in the `resolv.conf`.