### PR TITLE
chore: Fixate the k8s version to > 1.24

### DIFF
--- a/hack/e2e/aks-addon.sh
+++ b/hack/e2e/aks-addon.sh
@@ -109,6 +109,7 @@ cluster_subnet_id="$(az network vnet subnet show \
 if [ "$E2E_TARGET" = "pr" ]; then
 az aks create \
     -g "$RESOURCE_GROUP" \
+    --kubernetes-version "1.23.12" \
     -l "$LOCATION" \
     -c "$NODE_COUNT" \
     --node-vm-size standard_d8_v3 \
@@ -123,6 +124,7 @@ else
 
 az aks create \
     -g "$RESOURCE_GROUP" \
+    --kubernetes-version "1.23.12" \
     -l "$LOCATION" \
     -c "$NODE_COUNT" \
     --node-vm-size standard_d8_v3 \

--- a/hack/e2e/aks.sh
+++ b/hack/e2e/aks.sh
@@ -117,6 +117,7 @@ node_identity_client_id="$(az identity create --name "${RESOURCE_GROUP}-aks-iden
 if [ "$E2E_TARGET" = "pr" ]; then
 az aks create \
     -g "$RESOURCE_GROUP" \
+    --kubernetes-version "1.23.12" \
     -l "$LOCATION" \
     -c "$NODE_COUNT" \
     --node-vm-size standard_d8_v3 \
@@ -133,6 +134,7 @@ else
 
 az aks create \
     -g "$RESOURCE_GROUP" \
+    --kubernetes-version "1.23.12" \
     -l "$LOCATION" \
     -c "$NODE_COUNT" \
     --node-vm-size standard_d8_v3 \


### PR DESCRIPTION
Fix the k8s version until `virtual-kubelet` fixes the migration issue > 1.24
Signed-off-by: Heba Elayoty <hebaelayoty@gmail.com>