### PR TITLE
test: Pass k8s version as variable to e2e scripts

### DIFF
--- a/hack/e2e/aks-addon.sh
+++ b/hack/e2e/aks-addon.sh
@@ -40,6 +40,7 @@ fi
 : "${ACR_NAME=aksaddonacr$RANDOM_NUM}"
 : "${CSI_DRIVER_STORAGE_ACCOUNT_NAME=aksaddonvk$RANDOM_NUM}"
 : "${CSI_DRIVER_SHARE_NAME=vncsidriversharename}"
+: "${K8S_VERSION:=1.23.12}"
 
 error() {
     echo "$@" >&2
@@ -112,7 +113,7 @@ cluster_subnet_id="$(az network vnet subnet show \
 if [ "$E2E_TARGET" = "pr" ]; then
 az aks create \
     -g "$RESOURCE_GROUP" \
-    --kubernetes-version "1.23.12" \
+    --kubernetes-version "$K8S_VERSION" \
     -l "$LOCATION" \
     -c "$NODE_COUNT" \
     --node-vm-size standard_d8_v3 \
@@ -127,7 +128,7 @@ else
 
 az aks create \
     -g "$RESOURCE_GROUP" \
-    --kubernetes-version "1.23.12" \
+    --kubernetes-version "$K8S_VERSION" \
     -l "$LOCATION" \
     -c "$NODE_COUNT" \
     --node-vm-size standard_d8_v3 \

--- a/hack/e2e/aks.sh
+++ b/hack/e2e/aks.sh
@@ -40,6 +40,7 @@ fi
 : "${ACR_NAME=vkacr$RANDOM_NUM}"
 : "${CSI_DRIVER_STORAGE_ACCOUNT_NAME=vkcsidrivers$RANDOM_NUM}"
 : "${CSI_DRIVER_SHARE_NAME=vncsidriversharename}"
+: "${K8S_VERSION:=1.23.12}"
 
 error() {
     echo "$@" >&2
@@ -119,7 +120,7 @@ node_identity_client_id="$(az identity create --name "${RESOURCE_GROUP}-aks-iden
 if [ "$E2E_TARGET" = "pr" ]; then
 az aks create \
     -g "$RESOURCE_GROUP" \
-    --kubernetes-version "1.23.12" \
+    --kubernetes-version "$K8S_VERSION" \
     -l "$LOCATION" \
     -c "$NODE_COUNT" \
     --node-vm-size standard_d8_v3 \
@@ -136,7 +137,7 @@ else
 
 az aks create \
     -g "$RESOURCE_GROUP" \
-    --kubernetes-version "1.23.12" \
+    --kubernetes-version "$K8S_VERSION" \
     -l "$LOCATION" \
     -c "$NODE_COUNT" \
     --node-vm-size standard_d8_v3 \


### PR DESCRIPTION
Update `k8s-version` to be configurable for both `aks.sh` and `aks-addon.sh`

The default value is `1.23.12`

Signed-off-by: Heba Elayoty <hebaelayoty@gmail.com>