### PR TITLE
feat: report both old and new styles of node OS information

### DIFF
--- a/pkg/provider/vk_node.go
+++ b/pkg/provider/vk_node.go
@@ -7,6 +7,7 @@ package provider
 import (
 	"context"
 	"os"
+	"strings"
 
 	"github.com/virtual-kubelet/virtual-kubelet/trace"
 	v1 "k8s.io/api/core/v1"
@@ -25,6 +26,11 @@ func (p *ACIProvider) ConfigureNode(ctx context.Context, node *v1.Node) {
 	node.Status.NodeInfo.OperatingSystem = p.operatingSystem
 	node.ObjectMeta.Labels["alpha.service-controller.kubernetes.io/exclude-balancer"] = "true"
 	node.ObjectMeta.Labels["node.kubernetes.io/exclude-from-external-load-balancers"] = "true"
+
+	// report both old and new styles of OS information
+	os := strings.ToLower(p.operatingSystem)
+	node.ObjectMeta.Labels["beta.kubernetes.io/os"] = os
+	node.ObjectMeta.Labels["kubernetes.io/os"] = os
 
 	// Virtual node would be skipped for cloud provider operations (e.g. CP should not add route).
 	node.ObjectMeta.Labels["kubernetes.azure.com/managed"] = "false"


### PR DESCRIPTION
> spec.template.spec.nodeSelector[beta.kubernetes.io/os]: deprecated since v1.14; use "kubernetes.io/os" instead

To maintain compatibility, the virtual node should declare both styles of OS information, so that the Pod being scheduled to the virtual node can choose any of the following options
* use the legacy style `beta.kubernetes.io/os` nodeSelector
* migrate to use the new `kubernetes.io/os` nodeSelector before the `beta` one is dropped completely from API server

Currently, we only report `beta.kubernetes.io/os`, which will block the users from working on the nodeSelector migration.