### PR TITLE
fix: migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/e2e/fixtures/csi-driver.yml
+++ b/e2e/fixtures/csi-driver.yml
@@ -6,7 +6,7 @@ metadata:
 spec:
   nodeName: vk-aci-test-aks
   containers:
-  - image: k8s.gcr.io/hpa-example
+  - image: registry.k8s.io/hpa-example
     imagePullPolicy: Always
     name: hpa-example
     resources:
@@ -20,12 +20,12 @@ spec:
     - containerPort: 80
       name: http
       protocol: TCP
-  - image: busybox 
+  - image: busybox
     name: busybox
     imagePullPolicy: Always
     command: [
       "sh",
-      "-c", 
+      "-c",
       "sleep 10; while sleep 0.01; do wget -q -O- http://127.0.0.1; done",
     ]
     resources:

--- a/e2e/fixtures/hpa.yml
+++ b/e2e/fixtures/hpa.yml
@@ -6,7 +6,7 @@ metadata:
 spec:
   nodeName: vk-aci-test-aks
   containers:
-  - image: k8s.gcr.io/hpa-example
+  - image: registry.k8s.io/hpa-example
     imagePullPolicy: Always
     name: hpa-example
     resources:
@@ -20,12 +20,12 @@ spec:
     - containerPort: 443
       name: https
       protocol: TCP
-  - image: busybox 
+  - image: busybox
     name: busybox
     imagePullPolicy: Always
     command: [
       "sh",
-      "-c", 
+      "-c",
       "sleep 10; while sleep 0.01; do wget -q -O- http://127.0.0.1; done",
     ]
     resources:

--- a/e2e/fixtures/multi-volume.yml
+++ b/e2e/fixtures/multi-volume.yml
@@ -18,7 +18,7 @@ spec:
       requests:
         cpu: "1"
         memory: 1G
-  - image: k8s.gcr.io/hpa-example
+  - image: registry.k8s.io/hpa-example
     imagePullPolicy: Always
     name: hpa-example
     ports:


### PR DESCRIPTION
Kubernetes is migrating its image registry from [k8s.gcr.io](http://k8s.gcr.io/) to [registry.k8s.io](http://registry.k8s.io/).

Part of kubernetes/k8s.io#4780.