### PR TITLE
docs: Add instructions to install windows virtual node

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ In the following cases, users may need to install Virtual Kubelet manually.
 Note: Mannually installed virtual nodes are **NOT** managed by AKS anymore, they will not be upgraded automatically.
 
 ### Non-AKS Kubernetes clusters
-We do not support them. If you have specific requests for those clusters, please file an issue to describe the needs.
+We do not support non-AKS Kubernetes. If you have specific requests for those clusters, please file an issue to describe the needs.
 
 
 ## Demo

--- a/README.md
+++ b/README.md
@@ -47,7 +47,14 @@ Please follow this offical [document ](https://learn.microsoft.com/en-us/azure/a
 
 ### Deploy Virtual Kubelet manually using Helm 
 
-If you want to install a specific version of Virtual Kubelet in a Kubernetes cluster in Azure manually, please follow the documents ([downgrade](./docs/DOWNGRADE-README.md) and [upgrade](./docs/UPGRADE-README.md)).
+In the following cases, users may need to install Virtual Kubelet manually.
+- The ACI provider releases are rolled out to all AKS clusters that are configured with virtual node addon progressively. If the AKS managed version has problem, you can follow the [downgrade](./docs/DOWNGRADE-README.md) document to use a previous version or the [upgrade](./docs/UPGRADE-README.md) document to use the latest released version. In either case, a new virtual node will be created in the cluster.
+- Install a virtual node to support running windows ACI instances ([document](./docs/windows-virtual-node.md)).
+
+Note: Mannually installed virtual nodes are **NOT** managed by AKS anymore, they will not be upgraded automatically.
+
+### Non-AKS Kubernetes clusters
+We do not support them. If you have specific requests for those clusters, please file an issue to describe the needs.
 
 
 ## Demo

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Please follow this offical [document ](https://learn.microsoft.com/en-us/azure/a
 ### Deploy Virtual Kubelet manually using Helm 
 
 In the following cases, users may need to install Virtual Kubelet manually.
-- The ACI provider releases are rolled out to all AKS clusters that are configured with virtual node addon progressively. If the AKS managed version has problem, you can follow the [downgrade](./docs/DOWNGRADE-README.md) document to use a previous version or the [upgrade](./docs/UPGRADE-README.md) document to use the latest released version. In either case, a new virtual node will be created in the cluster.
+- The ACI provider releases are rolled out to all AKS clusters that are configured with virtual node addon progressively. If the AKS managed version has an issue, or there is an immediate need to use a new release that has not been rolled out yet,  you can follow the [downgrade](./docs/DOWNGRADE-README.md) document to use a previous version or the [upgrade](./docs/UPGRADE-README.md) document to use the latest released version. In either case, a new virtual node will be created in the cluster.
 - Install a virtual node to support running windows ACI instances ([document](./docs/windows-virtual-node.md)).
 
 Note: Mannually installed virtual nodes are **NOT** managed by AKS anymore, they will not be upgraded automatically.

--- a/docs/windows-virtual-node.md
+++ b/docs/windows-virtual-node.md
@@ -18,7 +18,7 @@ export MASTER_URI="$(kubectl cluster-info | awk '/Kubernetes control plane/{prin
 If you are using an AKS cluster, run the following command:
 ```bash
 helm install "$RELEASE_NAME" "$CHART_URL" \
-        --set "nodeOsType=Windows" \
+        --set nodeOsType=Windows \
         --set providers.azure.targetAKS=true \
         --set providers.azure.masterUri=$MASTER_URI \
         --set nodeName="${NODE_NAME}-win"

--- a/docs/windows-virtual-node.md
+++ b/docs/windows-virtual-node.md
@@ -1,0 +1,25 @@
+# Install an ACI plugin for running windows ACI instances
+
+ACI provides limited supports for running windows containers. The windows ACI instances do not support VNET, hence the configuration is simpler.
+
+
+## Prepare the env variables
+```bash
+export RELEASE_TAG=1.5.1  # or the latest released version
+export RELEASE_NAME=virtual-kubelet-azure-aci
+export VK_RELEASE=$RELEASE_NAME-$RELEASE_TAG
+export NODE_NAME=virtual-kubelet
+export CHART_URL=https://github.com/virtual-kubelet/azure-aci/raw/gh-pages/charts/$VK_RELEASE.tgz
+export MASTER_URI="$(kubectl cluster-info | awk '/Kubernetes control plane/{print $7}' | sed "s,\x1B\[[0-9;]*[a-zA-Z],,g")"
+```
+
+## Install the helm chart
+
+If you are using an AKS cluster, run the following command:
+```bash
+helm install "$RELEASE_NAME" "$CHART_URL" \
+        --set "nodeOsType=Windows" \
+        --set providers.azure.targetAKS=true \
+        --set providers.azure.masterUri=$MASTER_URI \
+        --set nodeName="${NODE_NAME}-win"
+```


### PR DESCRIPTION
The changes add the instructions for manually installing a virtual node to run windows ACI instances.