### PR TITLE
test: added unit test for cleanupDanglingPods

### DIFF
--- a/pkg/provider/podsTracker_test.go
+++ b/pkg/provider/podsTracker_test.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
+	azaciv2 "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerinstance/armcontainerinstance/v2"
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
 	testsutil "github.com/virtual-kubelet/azure-aci/pkg/tests"
+	"github.com/virtual-kubelet/virtual-kubelet/errdefs"
 	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -55,6 +59,101 @@ func TestUpdatePodStatus(t *testing.T) {
 			} else {
 				assert.Check(t, err != nil, "expecting an error")
 				assert.Check(t, strings.Contains(err.Error(), tc.failMessage), "failed message is expected")
+			}
+		})
+	}
+}
+
+func TestProcessPodUpdates(t *testing.T) {
+	podName := "pod-" + uuid.New().String()
+	podNamespace := "ns-" + uuid.New().String()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	aciMocks := createNewACIMock()
+
+	aciProvider, err := createTestProvider(aciMocks, NewMockConfigMapLister(mockCtrl),
+		NewMockSecretLister(mockCtrl), NewMockPodLister(mockCtrl))
+	if err != nil {
+		t.Fatal("failed to create the test provider", err)
+	}
+
+	pod := testsutil.CreatePodObj(podName, podNamespace)
+	containersList := testsutil.CreateACIContainersListObj(runningState, "Initializing",
+		testsutil.CgCreationTime.Add(time.Second*2), testsutil.CgCreationTime.Add(time.Second*3),
+		true, true, true)
+
+	cases := []struct {
+		description             string
+		podPhase                v1.PodPhase
+		getContainerGroupMock   func(ctx context.Context, resourceGroup, namespace, name, nodeName string) (*azaciv2.ContainerGroup, error)
+		shouldProcessPodUpdates bool
+	}{
+		{
+			description: "Pod is updated after retrieving the pod status from the provider",
+			podPhase:    v1.PodPending,
+			getContainerGroupMock: func(ctx context.Context, resourceGroup, namespace, name, nodeName string) (*azaciv2.ContainerGroup, error) {
+				return testsutil.CreateContainerGroupObj(podName, podNamespace, "Succeeded", containersList, "Succeeded"), nil
+			},
+			shouldProcessPodUpdates: true,
+		},
+		{
+			description: "Pod is updated after provider cannot retrieve the pod status but the pod is in a running state",
+			podPhase:    v1.PodRunning,
+			getContainerGroupMock: func(ctx context.Context, resourceGroup, namespace, name, nodeName string) (*azaciv2.ContainerGroup, error) {
+				return nil, errdefs.NotFound("cg is not found")
+			},
+			shouldProcessPodUpdates: true,
+		},
+		{
+			description:             "Pod status update is skipped because pod has reached a failed phase",
+			podPhase:                v1.PodFailed,
+			shouldProcessPodUpdates: false,
+		},
+		{
+			description: "Pod is not updated because pod status could not be retrieved from the provider and pod is not in running phase",
+			podPhase:    v1.PodPending,
+			getContainerGroupMock: func(ctx context.Context, resourceGroup, namespace, name, nodeName string) (*azaciv2.ContainerGroup, error) {
+				return nil, errdefs.NotFound("cg is not found")
+			},
+			shouldProcessPodUpdates: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			pod.Status.Phase = tc.podPhase
+			aciMocks.MockGetContainerGroupInfo = tc.getContainerGroupMock
+
+			podLister := NewMockPodLister(mockCtrl)
+
+			podsTracker := &PodsTracker{
+				pods:     podLister,
+				updateCb: func(p *v1.Pod) {},
+				handler:  aciProvider,
+			}
+
+			podUpdated := podsTracker.processPodUpdates(context.Background(), pod)
+
+			if !tc.shouldProcessPodUpdates {
+				assert.Equal(t, podUpdated, false, "pod should not be updated because it was not processed")
+			} else {
+				assert.Equal(t, podUpdated, true, "pod should be updated")
+
+				if tc.podPhase == v1.PodPending {
+					assert.Equal(t, pod.Status.Phase, v1.PodSucceeded, "Pod phase should be set to succeeded")
+					assert.Check(t, pod.Status.Conditions != nil, "podStatus conditions should be set")
+					assert.Check(t, pod.Status.StartTime != nil, "podStatus start time should be set")
+					assert.Check(t, pod.Status.ContainerStatuses != nil, "podStatus container statuses should be set")
+					assert.Check(t, is.Equal(len(pod.Status.Conditions), 3), "3 pod conditions should be present")
+				}
+
+				if tc.podPhase == v1.PodRunning {
+					assert.Equal(t, pod.Status.Phase, v1.PodFailed, "Pod status was not found so the pod phase should be set to failed")
+					assert.Equal(t, pod.Status.Reason, statusReasonNotFound, "Pod status was not found so the pod reason should be set to not found")
+					assert.Equal(t, pod.Status.Message, statusMessageNotFound, "Pod status was not found so the pod message should be set to not found")
+				}
 			}
 		})
 	}

--- a/pkg/provider/podsTracker_test.go
+++ b/pkg/provider/podsTracker_test.go
@@ -231,7 +231,7 @@ func TestCleanupDanglingPods(t *testing.T) {
 	podsTracker.cleanupDanglingPods(context.Background())
 
 	assert.Check(t, allPods[0].Status.ContainerStatuses[0].State.Terminated != nil, "Container should be terminated because pod was deleted")
-	assert.Check(t, is.Nil((allPods[0].Status.ContainerStatuses[0].State.Running)), "Container should not be running becuase pod was deleted")
+	assert.Check(t, is.Nil((allPods[0].Status.ContainerStatuses[0].State.Running)), "Container should not be running because pod was deleted")
 	assert.Check(t, is.Equal((allPods[0].Status.ContainerStatuses[0].State.Terminated.ExitCode), containerExitCodePodDeleted), "Status exit code should be set to pod deleted")
 	assert.Check(t, is.Equal((allPods[0].Status.ContainerStatuses[0].State.Terminated.Reason), statusReasonPodDeleted), "Status reason should be set to pod deleted")
 	assert.Check(t, is.Equal((allPods[0].Status.ContainerStatuses[0].State.Terminated.Message), statusMessagePodDeleted), "Status message code should be set to pod deleted")

--- a/pkg/tests/utils.go
+++ b/pkg/tests/utils.go
@@ -10,7 +10,7 @@ import (
 	azaciv2 "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerinstance/armcontainerinstance/v2"
 	"github.com/google/uuid"
 	"github.com/virtual-kubelet/azure-aci/pkg/util"
-	v12 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -183,54 +183,54 @@ func CreateCGProbeObj(hasHTTPGet, hasExec bool) *azaciv2.ContainerProbe {
 	}
 }
 
-func GetPodConditions(creationTime, readyConditionTime v1.Time, readyConditionStatus v12.ConditionStatus) []v12.PodCondition {
-	return []v12.PodCondition{
+func GetPodConditions(creationTime, readyConditionTime v1.Time, readyConditionStatus corev1.ConditionStatus) []corev1.PodCondition {
+	return []corev1.PodCondition{
 		{
-			Type:               v12.PodReady,
+			Type:               corev1.PodReady,
 			Status:             readyConditionStatus,
 			LastTransitionTime: readyConditionTime,
 		}, {
-			Type:               v12.PodInitialized,
-			Status:             v12.ConditionTrue,
+			Type:               corev1.PodInitialized,
+			Status:             corev1.ConditionTrue,
 			LastTransitionTime: creationTime,
 		}, {
-			Type:               v12.PodScheduled,
-			Status:             v12.ConditionTrue,
+			Type:               corev1.PodScheduled,
+			Status:             corev1.ConditionTrue,
 			LastTransitionTime: creationTime,
 		},
 	}
 }
 
-func CreatePodObj(podName, podNamespace string) *v12.Pod {
-	return &v12.Pod{
+func CreatePodObj(podName, podNamespace string) *corev1.Pod {
+	return &corev1.Pod{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      podName,
 			Namespace: podNamespace,
 		},
-		Spec: v12.PodSpec{
-			Containers: []v12.Container{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
 				{
 					Name: "nginx",
-					Ports: []v12.ContainerPort{
+					Ports: []corev1.ContainerPort{
 						{
 							Name:          "http",
 							ContainerPort: 8080,
 						},
 					},
-					Resources: v12.ResourceRequirements{
-						Requests: v12.ResourceList{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
 							"cpu":    resource.MustParse("0.99"),
 							"memory": resource.MustParse("1.5G"),
 						},
-						Limits: v12.ResourceList{
+						Limits: corev1.ResourceList{
 							"cpu":    resource.MustParse("3999m"),
 							"memory": resource.MustParse("8010M"),
 						},
 					},
 
-					LivenessProbe: &v12.Probe{
-						ProbeHandler: v12.ProbeHandler{
-							HTTPGet: &v12.HTTPGetAction{
+					LivenessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
 								Port: intstr.FromString("http"),
 								Path: "/",
 							},
@@ -241,9 +241,9 @@ func CreatePodObj(podName, podNamespace string) *v12.Pod {
 						SuccessThreshold:    3,
 						FailureThreshold:    5,
 					},
-					ReadinessProbe: &v12.Probe{
-						ProbeHandler: v12.ProbeHandler{
-							HTTPGet: &v12.HTTPGetAction{
+					ReadinessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
 								Port: intstr.FromInt(8080),
 								Path: "/",
 							},
@@ -260,19 +260,19 @@ func CreatePodObj(podName, podNamespace string) *v12.Pod {
 	}
 }
 
-func CreatePodProbeObj(hasHTTPGet, hasExec bool) *v12.Probe {
-	var httpGet *v12.HTTPGetAction
-	var exec *v12.ExecAction
+func CreatePodProbeObj(hasHTTPGet, hasExec bool) *corev1.Probe {
+	var httpGet *corev1.HTTPGetAction
+	var exec *corev1.ExecAction
 
 	if hasHTTPGet {
-		httpGet = &v12.HTTPGetAction{
+		httpGet = &corev1.HTTPGetAction{
 			Port:   intstr.FromString("http"),
 			Path:   "/",
 			Scheme: "http",
 		}
 	}
 	if hasExec {
-		exec = &v12.ExecAction{
+		exec = &corev1.ExecAction{
 			Command: []string{
 				"/bin/sh",
 				"-c",
@@ -281,16 +281,16 @@ func CreatePodProbeObj(hasHTTPGet, hasExec bool) *v12.Probe {
 		}
 	}
 
-	return &v12.Probe{
-		ProbeHandler: v12.ProbeHandler{
+	return &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
 			HTTPGet: httpGet,
 			Exec:    exec,
 		},
 	}
 }
 
-func CreateContainerPortObj(portName string, containerPort int32) []v12.ContainerPort {
-	return []v12.ContainerPort{
+func CreateContainerPortObj(portName string, containerPort int32) []corev1.ContainerPort {
+	return []corev1.ContainerPort{
 		{
 			Name:          portName,
 			ContainerPort: containerPort,
@@ -298,21 +298,21 @@ func CreateContainerPortObj(portName string, containerPort int32) []v12.Containe
 	}
 }
 
-func CreatePodVolumeObj(azureFileVolumeName string, fakeSecretName string, projectedVolumeName string) []v12.Volume {
+func CreatePodVolumeObj(azureFileVolumeName string, fakeSecretName string, projectedVolumeName string) []corev1.Volume {
 	emptyVolumeName := "emptyVolumeName"
 	fakeShareName1 := "aksshare1"
 
-	return []v12.Volume{
+	return []corev1.Volume{
 		{
 			Name: emptyVolumeName,
-			VolumeSource: v12.VolumeSource{
-				EmptyDir: &v12.EmptyDirVolumeSource{},
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
 		},
 		{
 			Name: azureFileVolumeName,
-			VolumeSource: v12.VolumeSource{
-				AzureFile: &v12.AzureFileVolumeSource{
+			VolumeSource: corev1.VolumeSource{
+				AzureFile: &corev1.AzureFileVolumeSource{
 					ShareName:  fakeShareName1,
 					SecretName: fakeSecretName,
 					ReadOnly:   true,
@@ -320,15 +320,15 @@ func CreatePodVolumeObj(azureFileVolumeName string, fakeSecretName string, proje
 			},
 		}, {
 			Name: projectedVolumeName,
-			VolumeSource: v12.VolumeSource{
-				Projected: &v12.ProjectedVolumeSource{
-					Sources: []v12.VolumeProjection{
+			VolumeSource: corev1.VolumeSource{
+				Projected: &corev1.ProjectedVolumeSource{
+					Sources: []corev1.VolumeProjection{
 						{
-							ConfigMap: &v12.ConfigMapProjection{
-								LocalObjectReference: v12.LocalObjectReference{
+							ConfigMap: &corev1.ConfigMapProjection{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "kube-root-ca.crt",
 								},
-								Items: []v12.KeyToPath{
+								Items: []corev1.KeyToPath{
 									{
 										Key:  "ca.crt",
 										Path: "ca.crt",
@@ -343,22 +343,22 @@ func CreatePodVolumeObj(azureFileVolumeName string, fakeSecretName string, proje
 	}
 }
 
-func CreatePodsList(podNames []string, podNameSpace string) []*v12.Pod {
-	result := make([]*v12.Pod, 0, len(podNames))
+func CreatePodsList(podNames []string, podNameSpace string) []*corev1.Pod {
+	result := make([]*corev1.Pod, 0, len(podNames))
 	for _, podName := range podNames {
-		pod := &v12.Pod{
+		pod := &corev1.Pod{
 			ObjectMeta: v1.ObjectMeta{
 				Name:              podName,
 				Namespace:         podNameSpace,
 				CreationTimestamp: v1.NewTime(time.Now()),
 				UID:               types.UID(uuid.New().String()),
 			},
-			Status: v12.PodStatus{
-				Phase: v12.PodRunning,
-				ContainerStatuses: []v12.ContainerStatus {
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{
 					{
-						State: v12.ContainerState {
-							Running: &v12.ContainerStateRunning{
+						State: corev1.ContainerState{
+							Running: &corev1.ContainerStateRunning{
 								StartedAt: v1.NewTime(time.Now()),
 							},
 						},


### PR DESCRIPTION
added unit test for cleanupDanglingPods in podsTracker.go
- test case: podLister returns an additional pod than what is reported by the client so the dangling pod is deleted so the two are in sync