### PR TITLE
test: Display code coverage for each func/pkg and the total coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,8 @@ unit-tests: testauth
 	LOCATION=$(LOCATION) AKS_CREDENTIAL_LOCATION=$(TEST_AKS_CREDENTIALS_JSON) \
 	AZURE_AUTH_LOCATION=$(TEST_CREDENTIALS_JSON) \
 	LOG_ANALYTICS_AUTH_LOCATION=$(TEST_LOGANALYTICS_JSON) \
-	go test -v $(shell go list ./... | grep -v /e2e) -race -coverprofile=coverage.out -covermode=atomic
+	go test -v $(shell go list ./... | grep -v /e2e) -race -coverprofile=coverage.out -covermode=atomic fmt
+	go tool cover -func=coverage.out
 
 .PHONY: e2e-test
 e2e-test:


### PR DESCRIPTION
Because the third-party extension (aka `codecov`) coverage can get delayed reporting back the code coverage, we wanted to display the full coverage report with the total with each run using go native way `go tool cover -func=coverage.out`.

