### PR TITLE
test: Add network testing mocks

### DIFF
--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -1,3 +1,7 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the Apache 2.0 license.
+*/
 package analytics
 
 import (

--- a/pkg/analytics/analytics_test.go
+++ b/pkg/analytics/analytics_test.go
@@ -1,3 +1,7 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the Apache 2.0 license.
+*/
 package analytics
 
 import (

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -1,3 +1,7 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the Apache 2.0 license.
+*/
 package auth
 
 import (

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -1,3 +1,7 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the Apache 2.0 license.
+*/
 package auth
 
 import (

--- a/pkg/client/client_apis.go
+++ b/pkg/client/client_apis.go
@@ -1,3 +1,7 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the Apache 2.0 license.
+*/
 package client
 
 import (

--- a/pkg/client/extensions.go
+++ b/pkg/client/extensions.go
@@ -1,3 +1,7 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the Apache 2.0 license.
+*/
 package client
 
 import (

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -1,3 +1,7 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the Apache 2.0 license.
+*/
 package client
 
 import (

--- a/pkg/featureflag/feature_flag_test.go
+++ b/pkg/featureflag/feature_flag_test.go
@@ -1,3 +1,7 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the Apache 2.0 license.
+*/
 package featureflag
 
 import (

--- a/pkg/metrics/cache.go
+++ b/pkg/metrics/cache.go
@@ -1,3 +1,7 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the Apache 2.0 license.
+*/
 package metrics
 
 import (

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,3 +1,7 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the Apache 2.0 license.
+*/
 package metrics
 
 import (

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,3 +1,7 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the Apache 2.0 license.
+*/
 package metrics
 
 import (

--- a/pkg/metrics/real_time.go
+++ b/pkg/metrics/real_time.go
@@ -1,3 +1,7 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the Apache 2.0 license.
+*/
 package metrics
 
 import (

--- a/pkg/metrics/real_time_test.go
+++ b/pkg/metrics/real_time_test.go
@@ -1,3 +1,7 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the Apache 2.0 license.
+*/
 package metrics
 
 import (

--- a/pkg/network/mock_aci_network.go
+++ b/pkg/network/mock_aci_network.go
@@ -3,3 +3,45 @@ Copyright (c) Microsoft Corporation.
 Licensed under the Apache 2.0 license.
 */
 package network
+
+import (
+	"context"
+
+	aznetworkv2 "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
+	"github.com/virtual-kubelet/azure-aci/pkg/auth"
+)
+
+type GetSubnetClientFunc func(ctx context.Context, azConfig *auth.Config) (*aznetworkv2.SubnetsClient, error)
+type GetACISubnetFunc func(ctx context.Context, subnetsClient *aznetworkv2.SubnetsClient) (aznetworkv2.Subnet, error)
+type CreateACISubnetFunc func(ctx context.Context, subnetsClient *aznetworkv2.SubnetsClient) error
+
+type MockProviderNetwork struct {
+	MockGetSubnetClient GetSubnetClientFunc
+	MockGetACISubnet    GetACISubnetFunc
+	MockCreateACISubnet CreateACISubnetFunc
+}
+
+func NewMockACINetwork() *MockProviderNetwork {
+	return &MockProviderNetwork{}
+}
+
+func (m *MockProviderNetwork) GetSubnetClient(ctx context.Context, azConfig *auth.Config) (*aznetworkv2.SubnetsClient, error) {
+	if m.MockGetSubnetClient != nil {
+		return m.MockGetSubnetClient(ctx, azConfig)
+	}
+	return nil, nil
+}
+
+func (m *MockProviderNetwork) GetACISubnet(ctx context.Context, subnetsClient *aznetworkv2.SubnetsClient) (aznetworkv2.Subnet, error) {
+	if m.MockGetACISubnet != nil {
+		return m.MockGetACISubnet(ctx, subnetsClient)
+	}
+	return aznetworkv2.Subnet{}, nil
+}
+
+func (m *MockProviderNetwork) CreateACISubnet(ctx context.Context, subnetsClient *aznetworkv2.SubnetsClient) error {
+	if m.MockCreateACISubnet != nil {
+		return m.MockCreateACISubnet(ctx, subnetsClient)
+	}
+	return nil
+}

--- a/pkg/network/mock_aci_network.go
+++ b/pkg/network/mock_aci_network.go
@@ -1,0 +1,5 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the Apache 2.0 license.
+*/
+package network

--- a/pkg/provider/aci_init_container_test.go
+++ b/pkg/provider/aci_init_container_test.go
@@ -1,3 +1,7 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the Apache 2.0 license.
+*/
 package provider
 
 import (

--- a/pkg/provider/config.go
+++ b/pkg/provider/config.go
@@ -1,3 +1,7 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the Apache 2.0 license.
+*/
 package provider
 
 import (

--- a/pkg/provider/config_test.go
+++ b/pkg/provider/config_test.go
@@ -1,3 +1,7 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the Apache 2.0 license.
+*/
 package provider
 
 import (

--- a/pkg/provider/docker_config.go
+++ b/pkg/provider/docker_config.go
@@ -1,3 +1,7 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the Apache 2.0 license.
+*/
 package provider
 
 import (

--- a/pkg/provider/docker_config_test.go
+++ b/pkg/provider/docker_config_test.go
@@ -1,3 +1,7 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the Apache 2.0 license.
+*/
 package provider
 
 import (

--- a/pkg/provider/mock_aci_test.go
+++ b/pkg/provider/mock_aci_test.go
@@ -1,3 +1,7 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the Apache 2.0 license.
+*/
 package provider
 
 import (

--- a/pkg/provider/podsTracker.go
+++ b/pkg/provider/podsTracker.go
@@ -1,3 +1,7 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the Apache 2.0 license.
+*/
 package provider
 
 import (

--- a/pkg/provider/podsTracker_test.go
+++ b/pkg/provider/podsTracker_test.go
@@ -1,3 +1,7 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the Apache 2.0 license.
+*/
 package provider
 
 import (

--- a/pkg/validation/validator.go
+++ b/pkg/validation/validator.go
@@ -1,3 +1,7 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the Apache 2.0 license.
+*/
 package validation
 
 import (


### PR DESCRIPTION
To be able to write unit tests for the `aci_network` package, we need to mock the networking client along with create/get APIs.

In order to achieve that, we introduce a new interface, `ProviderNetworkInterface` that will implement:
- getSubnetClient
- getACISubnet
- getACISubnet

>> Note: A separate commit has been added for missing copyright headers in some files. 
