### PR TITLE
test: added unit test for validateNetworkConfig

### DIFF
--- a/pkg/network/aci_network_test.go
+++ b/pkg/network/aci_network_test.go
@@ -288,6 +288,8 @@ func TestValidateNetworkConfig(t *testing.T) {
 		{
 			description: "ACI subnet CIDR env variable is set but subnet name is missing",
 			setEnvVar: func() {
+				os.Setenv("ACI_VNET_SUBSCRIPTION_ID", "111111-222-3333-4444-555555")
+				os.Setenv("ACI_VNET_NAME", "fakeVnet")
 				os.Setenv("ACI_VNET_RESOURCE_GROUP", "fakeRG")
 				os.Setenv("ACI_SUBNET_CIDR", "10.00.0/16")
 			},
@@ -296,6 +298,10 @@ func TestValidateNetworkConfig(t *testing.T) {
 		{
 			description: "ACI subnet CIDR env variable is set but it is malformed",
 			setEnvVar: func() {
+				os.Setenv("ACI_VNET_SUBSCRIPTION_ID", "111111-222-3333-4444-555555")
+				os.Setenv("ACI_VNET_NAME", "fakeVnet")
+				os.Setenv("ACI_VNET_RESOURCE_GROUP", "fakeRG")
+				os.Setenv("ACI_SUBNET_CIDR", "10.00.0/16")
 				os.Setenv("ACI_SUBNET_NAME", "fakeSubnet")
 			},
 			expectedError: errors.New("error parsing provided subnet CIDR: invalid CIDR address: 10.00.0/16"),
@@ -303,6 +309,11 @@ func TestValidateNetworkConfig(t *testing.T) {
 		{
 			description: "all environmental variables are set as expected",
 			setEnvVar: func() {
+				os.Setenv("ACI_VNET_SUBSCRIPTION_ID", "111111-222-3333-4444-555555")
+				os.Setenv("ACI_VNET_NAME", "fakeVnet")
+				os.Setenv("ACI_VNET_RESOURCE_GROUP", "fakeRG")
+				os.Setenv("ACI_SUBNET_CIDR", "10.00.0/16")
+				os.Setenv("ACI_SUBNET_NAME", "fakeSubnet")
 				os.Setenv("ACI_SUBNET_CIDR", "127.0.0.1/24")
 			},
 			expectedError: nil,

--- a/pkg/network/aci_network_test.go
+++ b/pkg/network/aci_network_test.go
@@ -260,41 +260,115 @@ func TestShouldCreateSubnet(t *testing.T) {
 
 func TestValidateNetworkConfig(t *testing.T) {
 	azConfig := auth.Config{}
+
 	err := azConfig.SetAuthConfig(context.TODO())
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	cases := []struct {
-		description   string
-		setEnvVar     func()
-		expectedError error
+		description        string
+		providerNetwork    *ProviderNetwork
+		setEnvVar          func()
+		expectedAssertions func(pn *ProviderNetwork) bool
+		expectedError      error
 	}{
 		{
-			description:   "ACI vnet name env variable is not set",
-			setEnvVar:     func() {},
+			description:     "Neither provider Vnet name nor env variable is set",
+			providerNetwork: &ProviderNetwork{},
+			setEnvVar:       func() {},
+			expectedAssertions: func(pn *ProviderNetwork) bool {
+				return assert.Equal(t, pn.VnetSubscriptionID, azConfig.AuthConfig.SubscriptionID, "ACI Vnet subscription ID env variable was not set so it should default to what is present in authconfig") &&
+					assert.Equal(t, pn.VnetName, "")
+			},
 			expectedError: errors.New("vnet name can not be empty please set ACI_VNET_NAME"),
 		},
 		{
-			description: "ACI vnet resource group env variable is not set",
+			description: "Provider Vnet name, RG, and subnetName is set but env variable is not set",
+			providerNetwork: &ProviderNetwork{
+				VnetName:          "fakeVnet2",
+				VnetResourceGroup: "fakeRG2",
+				SubnetName:        "fakeSubnet2",
+			},
+			setEnvVar: func() {
+				os.Setenv("ACI_VNET_SUBSCRIPTION_ID", "111111-222-3333-4444-555555")
+			},
+			expectedAssertions: func(pn *ProviderNetwork) bool {
+				return assert.Equal(t, pn.VnetSubscriptionID, os.Getenv("ACI_VNET_SUBSCRIPTION_ID")) &&
+					assert.Equal(t, pn.VnetName, "fakeVnet2") && assert.Equal(t, pn.VnetResourceGroup, "fakeRG2") &&
+					assert.Equal(t, pn.SubnetName, "fakeSubnet2")
+			},
+			expectedError: nil,
+		},
+		{
+			description:     "Provider Vnet name is not set but env variable is set and neither is set for vnet resource group",
+			providerNetwork: &ProviderNetwork{},
 			setEnvVar: func() {
 				os.Setenv("ACI_VNET_SUBSCRIPTION_ID", "111111-222-3333-4444-555555")
 				os.Setenv("ACI_VNET_NAME", "fakeVnet")
 			},
+			expectedAssertions: func(pn *ProviderNetwork) bool {
+				return assert.Equal(t, pn.VnetSubscriptionID, os.Getenv("ACI_VNET_SUBSCRIPTION_ID")) &&
+					assert.Equal(t, pn.VnetName, os.Getenv("ACI_VNET_NAME"))
+			},
 			expectedError: errors.New("vnet resourceGroup can not be empty please set ACI_VNET_RESOURCE_GROUP"),
 		},
 		{
-			description: "ACI subnet CIDR env variable is set but subnet name is missing",
+			description:     "Provider Vnet RG is not set, but the env variable is set",
+			providerNetwork: &ProviderNetwork{},
+			setEnvVar: func() {
+				os.Setenv("ACI_VNET_SUBSCRIPTION_ID", "111111-222-3333-4444-555555")
+				os.Setenv("ACI_VNET_NAME", "fakeVnet")
+				os.Setenv("ACI_VNET_RESOURCE_GROUP", "fakeRG")
+			},
+			expectedAssertions: func(pn *ProviderNetwork) bool {
+				return assert.Equal(t, pn.VnetSubscriptionID, os.Getenv("ACI_VNET_SUBSCRIPTION_ID")) &&
+					assert.Equal(t, pn.VnetName, os.Getenv("ACI_VNET_NAME")) &&
+					assert.Equal(t, pn.VnetResourceGroup, os.Getenv(("ACI_VNET_RESOURCE_GROUP")))
+			},
+			expectedError: nil,
+		},
+		{
+			description:     "Neither provider, nor env variable is set for subnet name but subnet cidr env variable is set",
+			providerNetwork: &ProviderNetwork{},
 			setEnvVar: func() {
 				os.Setenv("ACI_VNET_SUBSCRIPTION_ID", "111111-222-3333-4444-555555")
 				os.Setenv("ACI_VNET_NAME", "fakeVnet")
 				os.Setenv("ACI_VNET_RESOURCE_GROUP", "fakeRG")
 				os.Setenv("ACI_SUBNET_CIDR", "10.00.0/16")
 			},
+			expectedAssertions: func(pn *ProviderNetwork) bool {
+				return assert.Equal(t, pn.VnetSubscriptionID, os.Getenv("ACI_VNET_SUBSCRIPTION_ID")) &&
+					assert.Equal(t, pn.VnetName, os.Getenv("ACI_VNET_NAME")) &&
+					assert.Equal(t, pn.VnetResourceGroup, os.Getenv("ACI_VNET_RESOURCE_GROUP")) &&
+					assert.Equal(t, pn.SubnetName, "")
+			},
 			expectedError: errors.New("subnet CIDR defined but no subnet name, subnet name is required to set a subnet CIDR"),
 		},
 		{
-			description: "ACI subnet CIDR env variable is set but it is malformed",
+			description: "Both provider and env variable is set for Vnet name, Vnet RG, and subnet name",
+			providerNetwork: &ProviderNetwork{
+				VnetName:          "fakeVnet2",
+				VnetResourceGroup: "fakeRG2",
+				SubnetName:        "fakeSubnet2",
+			},
+			setEnvVar: func() {
+				os.Setenv("ACI_VNET_SUBSCRIPTION_ID", "111111-222-3333-4444-555555")
+				os.Setenv("ACI_VNET_NAME", "fakeVnet")
+				os.Setenv("ACI_VNET_RESOURCE_GROUP", "fakeRG")
+				os.Setenv("ACI_SUBNET_NAME", "fakeSubnet")
+			},
+			expectedAssertions: func(pn *ProviderNetwork) bool {
+				return assert.Equal(t, pn.VnetSubscriptionID, os.Getenv("ACI_VNET_SUBSCRIPTION_ID")) &&
+					assert.Equal(t, pn.VnetName, os.Getenv("ACI_VNET_NAME")) &&
+					assert.Equal(t, pn.VnetResourceGroup, os.Getenv("ACI_VNET_RESOURCE_GROUP")) &&
+					assert.Equal(t, pn.SubnetName, os.Getenv("ACI_SUBNET_NAME"))
+			},
+			expectedError: nil,
+		},
+		{
+			description:     "Provider subnet name is not set, but the env variable is set and it is malformed",
+			providerNetwork: &ProviderNetwork{},
 			setEnvVar: func() {
 				os.Setenv("ACI_VNET_SUBSCRIPTION_ID", "111111-222-3333-4444-555555")
 				os.Setenv("ACI_VNET_NAME", "fakeVnet")
@@ -302,10 +376,17 @@ func TestValidateNetworkConfig(t *testing.T) {
 				os.Setenv("ACI_SUBNET_CIDR", "10.00.0/16")
 				os.Setenv("ACI_SUBNET_NAME", "fakeSubnet")
 			},
+			expectedAssertions: func(pn *ProviderNetwork) bool {
+				return assert.Equal(t, pn.VnetSubscriptionID, os.Getenv("ACI_VNET_SUBSCRIPTION_ID")) &&
+					assert.Equal(t, pn.VnetName, os.Getenv("ACI_VNET_NAME")) &&
+					assert.Equal(t, pn.VnetResourceGroup, os.Getenv("ACI_VNET_RESOURCE_GROUP")) &&
+					assert.Equal(t, pn.SubnetName, os.Getenv("ACI_SUBNET_NAME"))
+			},
 			expectedError: errors.New("error parsing provided subnet CIDR: invalid CIDR address: 10.00.0/16"),
 		},
 		{
-			description: "all environmental variables are set as expected",
+			description:     "Provider subnet name is not set, but the env variable is set and it is valid",
+			providerNetwork: &ProviderNetwork{},
 			setEnvVar: func() {
 				os.Setenv("ACI_VNET_SUBSCRIPTION_ID", "111111-222-3333-4444-555555")
 				os.Setenv("ACI_VNET_NAME", "fakeVnet")
@@ -313,6 +394,13 @@ func TestValidateNetworkConfig(t *testing.T) {
 				os.Setenv("ACI_SUBNET_CIDR", "10.00.0/16")
 				os.Setenv("ACI_SUBNET_NAME", "fakeSubnet")
 				os.Setenv("ACI_SUBNET_CIDR", "127.0.0.1/24")
+			},
+			expectedAssertions: func(pn *ProviderNetwork) bool {
+				return assert.Equal(t, pn.VnetSubscriptionID, os.Getenv("ACI_VNET_SUBSCRIPTION_ID")) &&
+					assert.Equal(t, pn.VnetName, os.Getenv("ACI_VNET_NAME")) &&
+					assert.Equal(t, pn.VnetResourceGroup, os.Getenv("ACI_VNET_RESOURCE_GROUP")) &&
+					assert.Equal(t, pn.SubnetName, os.Getenv("ACI_SUBNET_NAME")) &&
+					assert.Equal(t, pn.SubnetCIDR, os.Getenv("ACI_SUBNET_CIDR"))
 			},
 			expectedError: nil,
 		},
@@ -322,17 +410,13 @@ func TestValidateNetworkConfig(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			tc.setEnvVar()
 
-			pn := &ProviderNetwork{}
+			pn := tc.providerNetwork
 			err := pn.validateNetworkConfig(context.Background(), &azConfig)
+
+			assert.Equal(t, tc.expectedAssertions(pn), true, "Expected assertions should pass")
 
 			if tc.expectedError != nil {
 				assert.Equal(t, err.Error(), tc.expectedError.Error(), "Error messages should match")
-			} else {
-				assert.Equal(t, pn.VnetSubscriptionID, os.Getenv("ACI_VNET_SUBSCRIPTION_ID"))
-				assert.Equal(t, pn.VnetName, os.Getenv("ACI_VNET_NAME"))
-				assert.Equal(t, pn.VnetResourceGroup, os.Getenv("ACI_VNET_RESOURCE_GROUP"))
-				assert.Equal(t, pn.SubnetName, os.Getenv("ACI_SUBNET_NAME"))
-				assert.Equal(t, pn.SubnetCIDR, os.Getenv("ACI_SUBNET_CIDR"))
 			}
 		})
 	}

--- a/pkg/network/aci_network_test.go
+++ b/pkg/network/aci_network_test.go
@@ -265,8 +265,6 @@ func TestValidateNetworkConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pn := &ProviderNetwork{}
-
 	cases := []struct {
 		description   string
 		setEnvVar     func()
@@ -323,6 +321,8 @@ func TestValidateNetworkConfig(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.description, func(t *testing.T) {
 			tc.setEnvVar()
+
+			pn := &ProviderNetwork{}
 			err := pn.validateNetworkConfig(context.Background(), &azConfig)
 
 			if tc.expectedError != nil {


### PR DESCRIPTION
added unit test coverage for validateNetworkConfig in aci_network.go

Test case break down:

### Vnet name
- Provider Vnet name is set but environment variable is not: tc2
- Provider Vnet name is not set but environment variable is: tc3
- Both provider Vnet name and environment variable is set: tc6
- Neither provider Vnet name nor environment variable is set: tc1

### Vnet resource group
- Provider Vnet resource group is set but environment variable is not: tc2
- Provider Vnet resource group is not set but environment variable is: tc4
- Both provider Vnet resource group and environment variable is set: tc6
- Neither provider Vnet resource group nor environment variable is set: tc3

### Subnet name
- Provider Subnet name is set but environment variable is not: tc2
- Provider Subnet name is not set but environment variable is
-- malformed: tc7
--valid: tc8
- Both provider Subnet name and environment variable is set: tc6
- Neither provider Subnet name nor environment variable is set: tc5
