### PR TITLE
ci: Use pull_request in the e2e pipelines

### DIFF
--- a/.github/workflows/aks-addon-tests.yml
+++ b/.github/workflows/aks-addon-tests.yml
@@ -5,7 +5,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [master]
     paths-ignore: ['docs/**', '**.md', '**.mdx', '**.png', '**.jpg']
   push:
@@ -34,7 +34,6 @@ jobs:
 
   aks-addon-e2e-tests:
     needs: export-registry
-    environment: test
     env:
       REGISTRY: ${{ needs.export-registry.outputs.registry }}
       E2E_IMG_TAG: "e2e-ci"
@@ -70,18 +69,18 @@ jobs:
           curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
           az version
 
-      - uses: azure/login@v1.4.6
+      - uses: azure/login@v1
         with:
-          client-id: ${{ secrets.CLIENTID }}
-          tenant-id: ${{ secrets.TENANT_ID }}
-          subscription-id: ${{ secrets.SUBSCRIPTIONID }}
+          client-id: ${{ env.CLIENTID }}
+          tenant-id: ${{ env.TENANT_ID }}
+          subscription-id: ${{ env.SUBSCRIPTIONID }}
 
       - name: Run e2e test
         run: |
           OUTPUT_TYPE=type=registry make aks-addon-e2e-test
         env:
           REGISTRY: ${{ env.REGISTRY}}
-          E2E_REGION: ${{ secrets.E2E_REGION}}
+          E2E_REGION: ${{ env.E2E_REGION}}
           CLUSTER_NAME: ${{ env.CLUSTER_NAME }}
           VERSION: ${{ env.E2E_IMG_TAG}}
           E2E_TARGET: "pr"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -5,14 +5,14 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  workflow_dispatch:
-  pull_request_target:
+  pull_request:
     branches:
       - master
       - release-**
     types: [ opened, ready_for_review, reopened ]
     paths:
       - '.github/workflows/chart.yml'
+      - '.github/workflows/e2e-tests.yml'
       - 'charts/**'
 
 permissions:
@@ -37,7 +37,6 @@ jobs:
 
   e2e-tests:
     needs: export-registry
-    environment: test
     env:
       REGISTRY: ${{ needs.export-registry.outputs.registry }}
       E2E_IMG_TAG: "e2e-ci"
@@ -73,18 +72,18 @@ jobs:
           curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
           az version
 
-      - uses: azure/login@v1.4.6
+      - uses: azure/login@v1
         with:
-          client-id: ${{ secrets.CLIENTID }}
-          tenant-id: ${{ secrets.TENANT_ID }}
-          subscription-id: ${{ secrets.SUBSCRIPTIONID }}
+          client-id: ${{ env.CLIENTID }}
+          tenant-id: ${{ env.TENANT_ID }}
+          subscription-id: ${{ env.SUBSCRIPTIONID }}
 
       - name: Run e2e test
         run: |
           OUTPUT_TYPE=type=registry make e2e-test
         env:
           REGISTRY: ${{ env.REGISTRY}}
-          E2E_REGION: ${{ secrets.E2E_REGION}}
+          E2E_REGION: ${{ env.E2E_REGION}}
           CLUSTER_NAME: ${{ env.CLUSTER_NAME }}
           VERSION: ${{ env.E2E_IMG_TAG}}
           E2E_TARGET: "pr"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,6 @@ env:
 jobs:
   unit-tests:
     runs-on: ubuntu-20.04
-    environment: test
     steps:
       - name:  Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v4


### PR DESCRIPTION
Use `pull_request` action instead of `pull_request_target` to prevent security risks.