### PR TITLE
fix: issue 579 and error handling when aci provider fail to be initialized

### DIFF
--- a/charts/virtual-kubelet/templates/deployment.yaml
+++ b/charts/virtual-kubelet/templates/deployment.yaml
@@ -16,8 +16,6 @@ spec:
         component: kubelet
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
-      labels:
-        app: {{ template "vk.fullname" . }}
     spec:
       initContainers:
         - name: init-validation

--- a/cmd/virtual-kubelet/main.go
+++ b/cmd/virtual-kubelet/main.go
@@ -222,6 +222,9 @@ func main() {
 				p, err := azproviderv2.NewACIProvider(ctx, cfgPath, azConfig, azACIAPIs, cfg,
 					nodeName, operatingSystem, os.Getenv("VKUBELET_POD_IP"),
 					int32(listenPort), clusterDomain, k8sClient)
+				if err != nil {
+					return nil, nil, err
+				}
 				p.ConfigureNode(ctx, cfg.Node)
 				return p, nil, err
 			},


### PR DESCRIPTION
- #579 : removing duplicate app label from deployment file as it will be populated from the helper file
- added error handling so VK does not crash in the case aci provider fails to be initialized 