### PR TITLE
chore: updating permissions for workflow files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,11 @@
 version: 2
+
+permissions:
+  pull-requests: write
+  security-events: write
+  contents: read
+  actions: read
+
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/aks-addon-tests.yml
+++ b/.github/workflows/aks-addon-tests.yml
@@ -20,6 +20,8 @@ env:
 permissions:
   id-token: write # This is required for requesting the JWT
   contents: read # This is required for actions/checkout
+  actions: read #This is required for reading environment variables
+  deployments: read #This is required for reading deployment status
 
 jobs:
   aks-addon-e2e-tests:

--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -9,6 +9,9 @@ on:
 
 permissions:
   contents: write
+  actions: read
+  deployments: read
+  contents: read
 
 jobs:
   publish-helm-chart:

--- a/.github/workflows/create-release-pull-request.yml
+++ b/.github/workflows/create-release-pull-request.yml
@@ -14,6 +14,8 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: read
+  deployments: read
 
 jobs:
   create-release-pull-request:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -10,7 +10,9 @@ on:
 permissions:
   contents: write
   packages: write
-
+  actions: read
+  deployments: read
+  pull-requests: read
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -20,8 +20,10 @@ env:
   E2E_IMG_TAG: "e2e-ci"
 
 permissions:
-   id-token: write
-   contents: read
+  id-token: write
+  contents: read
+  actions: read
+  deployments: read
 
 jobs:
   e2e-tests:

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -6,6 +6,11 @@ on:
       - '**.md'
       - 'docs/**'
 
+permissions:
+  contents: read
+  actions: read
+  deployments: read
+
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -8,6 +8,11 @@ on:
       - labeled
       - unlabeled
 
+permissions:
+  contents: read
+  actions: read
+  deployments: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,12 @@ env:
   # Common versions
   GO_VERSION: '1.20'
 
+permissions:
+  pull-requests: write
+  contents: read
+  actions: read
+  deployments: read
+
 jobs:
   unit-tests:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Updating/adding permissions block for workflow file according to [breaking change doc](https://docs.opensource.microsoft.com/github/apps/permission-changes/)

- List of available scopes: https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-syntax-for-github-actions#permissions
- Permission breakdown per scope: https://docs.github.com/en/enterprise-cloud@latest/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-pull-requests