### PR TITLE
fix: dependabot workflow config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,4 @@
 version: 2
-
-permissions:
-  pull-requests: write
-  security-events: write
-  contents: read
-  actions: read
-
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Removing permissions field from config file 