### PR TITLE
fix: fix e2e failed cases

### DIFF
--- a/e2e/fixtures/csi-driver.yml
+++ b/e2e/fixtures/csi-driver.yml
@@ -24,7 +24,7 @@ spec:
     name: busybox
     imagePullPolicy: Always
     command: [
-      "sh",
+      "/bin/sh",
       "-c",
       "sleep 10; while sleep 0.01; do wget -q -O- http://127.0.0.1; done",
     ]

--- a/e2e/fixtures/hpa.yml
+++ b/e2e/fixtures/hpa.yml
@@ -24,7 +24,7 @@ spec:
     name: busybox
     imagePullPolicy: Always
     command: [
-      "sh",
+      "/bin/sh",
       "-c",
       "sleep 10; while sleep 0.01; do wget -q -O- http://127.0.0.1; done",
     ]

--- a/e2e/fixtures/multi-volume.yml
+++ b/e2e/fixtures/multi-volume.yml
@@ -10,7 +10,7 @@ spec:
     imagePullPolicy: Always
     name: busybox
     command:  [
-      "sh",
+      "/bin/sh",
       "-c",
       "sleep 10; while sleep 0.01; do wget -q -O- http://127.0.0.1; done",
     ]


### PR DESCRIPTION
E2E pipeline has been failing due to timeout. Impacted test cases: TestPodLifecycle, TestPodWithCSIDriver, TestPodWithMultiVolume

`Error: Failed to start container busybox, Error response: to create containerd task: failed to create shim task: failed to create container 13497419b8081cc7082dadd06ce7883bdb5d490b69e4ffbea77331f89ab95744: guest RPC failure: failed to create container: failed to run runc create/exec call for container 13497419b8081cc7082dadd06ce7883bdb5d490b69e4ffbea77331f89ab95744 with exit status 1: container_linux.go:380: starting container process caused: exec: "sh": executable file not found in $PATH: unknown`

Fix: specifying /bin/sh seems to do the trick