### PR TITLE
[BUG FIX] Add logic to check properties.AddressPrefixes of a subnet 

### DIFF
--- a/pkg/network/aci_network.go
+++ b/pkg/network/aci_network.go
@@ -161,23 +161,23 @@ func (pn *ProviderNetwork) shouldCreateSubnet(currentSubnet aznetworkv2.Subnet, 
 		}
 		if pn.SubnetCIDR != *currentSubnet.Properties.AddressPrefix {
 			return false, fmt.Errorf("found subnet '%s' using different CIDR: '%s'. desired: '%s'", pn.SubnetName, *currentSubnet.Properties.AddressPrefix, pn.SubnetCIDR)
+		} else if len(currentSubnet.Properties.AddressPrefixes) > 0 {
+
+			firstPrefix := currentSubnet.Properties.AddressPrefixes[0]
+			if pn.SubnetCIDR == "" {
+				pn.SubnetCIDR = firstPrefix
+			}
+			if pn.SubnetCIDR != firstPrefix {
+				return false, fmt.Errorf("found subnet '%s' using different CIDR: '%s'. desired: '%s'", pn.SubnetName, firstPrefix, pn.SubnetCIDR)
+			}
+		} else {
+			return false, fmt.Errorf("both AddressPrefix and AddressPrefixes for subnet '%s' are not set", pn.SubnetName)
 		}
-	} else if len(currentSubnet.Properties.AddressPrefixes) > 0 {
-		// Assuming we want to use the first address prefix if available
-		firstPrefix := currentSubnet.Properties.AddressPrefixes[0]
-		if pn.SubnetCIDR == "" {
-			pn.SubnetCIDR = firstPrefix
+
+		if currentSubnet.Properties.RouteTable != nil {
+			return false, fmt.Errorf("unable to delegate subnet '%s' to Azure Container Instance since it references the route table '%s'", pn.SubnetName, *currentSubnet.Properties.RouteTable.ID)
 		}
-		if pn.SubnetCIDR != firstPrefix {
-			return false, fmt.Errorf("found subnet '%s' using different CIDR: '%s'. desired: '%s'", pn.SubnetName, firstPrefix, pn.SubnetCIDR)
-		}
-	} else {
-		return false, fmt.Errorf("both AddressPrefix and AddressPrefixes for subnet '%s' are not set", pn.SubnetName)
-	}
-	
-	if currentSubnet.Properties.RouteTable != nil {
-		return false, fmt.Errorf("unable to delegate subnet '%s' to Azure Container Instance since it references the route table '%s'", pn.SubnetName, *currentSubnet.Properties.RouteTable.ID)
-	}
+
 		if currentSubnet.Properties.ServiceAssociationLinks != nil {
 			for _, l := range currentSubnet.Properties.ServiceAssociationLinks {
 				if l.Properties != nil && l.Properties.LinkedResourceType != nil {


### PR DESCRIPTION
Changes:
Add logic to check both properties.AddressPrefix and properties.AddressPrefixes.  properties.AddressPrefix is a list, so the first element in the list is selected

Reasoning:
 
Azure subnets are inconsistent with address prefix within the properties object. This may be due to a new feature where multiple prefixes can be added to a subnet: https://learn.microsoft.com/en-us/azure/virtual-network/how-to-multiple-prefixes-subnet?tabs=powershell.

For example, here is a subnet that has properties.addressPrefix: 
<img width="312" alt="image" src="https://github.com/user-attachments/assets/bd417ec3-41f3-4447-8b77-c99c742c3ebd">

and here is a subnet that instead has properties.addressPrefixes: 
<img width="297" alt="image" src="https://github.com/user-attachments/assets/f70e58d3-a7ab-453b-a77f-73ad3159d80d">

The latter causes the aci-connector-linux pod to fail because the code is attempting to obtain the prefix value from properties.addressPrefix, when it does not exist (returns a null/empty value).  The error can be seen within the pod logs:

`level=fatal msg="error creating provider: error setting up network: error creating subnet: PUT https://management.azure.com/subscriptions/7b7e8f8d-c692-4cc9-ba51-549aed510ea3/resourceGroups/rg-aks-lab/providers/Microsoft.Network/virtualNetworks/vnet-aks-lab/subnets/virtual_node_subnet\n--------------------------------------------------------------------------------\nRESPONSE 400: 400 Bad Request\nERROR CODE: AddressPrefixStringCannotBeNullOrEmpty\n--------------------------------------------------------------------------------\n{\n \"error\": {\n \"code\": \"AddressPrefixStringCannotBeNullOrEmpty\",\n \"message\": \"Address prefix string for resource /subscriptions//resourceGroups/rg-aks-lab/providers/Microsoft.Network/virtualNetworks/vnet-aks-lab/subnets/virtual_node_subnet cannot be null or empty.\",\n \"details\": []\n }\n}\n--------------------------------------------------------------------------------\n"`
