### PR TITLE
fix: update image registry to MCR

### DIFF
--- a/e2e/fixtures/confidential_container_pod.yml
+++ b/e2e/fixtures/confidential_container_pod.yml
@@ -8,7 +8,7 @@ metadata:
 spec:
   restartPolicy: Always
   containers:
-  - image: docker.io/kengordon/parmasimple:latest
+  - image: mcr.microsoft.com/aci/aci-confidential-helloworld:v1
     imagePullPolicy: Always
     name: e2etest-conf-container
     resources:

--- a/e2e/fixtures/csi-driver.yml
+++ b/e2e/fixtures/csi-driver.yml
@@ -20,7 +20,7 @@ spec:
     - containerPort: 80
       name: http
       protocol: TCP
-  - image: busybox
+  - image: mcr.microsoft.com/cbl-mariner/busybox:1.35
     name: busybox
     imagePullPolicy: Always
     command: [

--- a/e2e/fixtures/hpa.yml
+++ b/e2e/fixtures/hpa.yml
@@ -20,7 +20,7 @@ spec:
     - containerPort: 443
       name: https
       protocol: TCP
-  - image: busybox
+  - image: mcr.microsoft.com/cbl-mariner/busybox:1.35
     name: busybox
     imagePullPolicy: Always
     command: [

--- a/e2e/fixtures/initcontainers_ordertest_pod.yml
+++ b/e2e/fixtures/initcontainers_ordertest_pod.yml
@@ -6,14 +6,14 @@ metadata:
 spec:
   nodeName: vk-aci-test-aks
   initContainers:
-  - image: alpine
+  - image: mcr.microsoft.com/mirror/docker/library/alpine:3.16
     name: init-container-01
     command: [ "/bin/sh" ]
     args: [ "-c", "echo Hi from init-container-01 >> /mnt/azure/newfile.txt" ]
     volumeMounts:
       - name: azure
         mountPath: /mnt/azure
-  - image: alpine
+  - image: mcr.microsoft.com/mirror/docker/library/alpine:3.16
     name: init-container-02
     command: [ "/bin/sh" ]
     args: [ "-c", "echo Hi from init-container-02 >> /mnt/azure/newfile.txt" ]
@@ -21,7 +21,7 @@ spec:
       - name: azure
         mountPath: /mnt/azure
   containers:
-  - image: alpine
+  - image: mcr.microsoft.com/mirror/docker/library/alpine:3.16
     imagePullPolicy: Always
     name: container
     command: [

--- a/e2e/fixtures/multi-volume.yml
+++ b/e2e/fixtures/multi-volume.yml
@@ -6,7 +6,7 @@ metadata:
 spec:
   nodeName: vk-aci-test-aks
   containers:
-  - image: busybox
+  - image: mcr.microsoft.com/cbl-mariner/busybox:1.35
     imagePullPolicy: Always
     name: busybox
     command:  [


### PR DESCRIPTION
Changing e2e test pods image registry from docker to MCR as a part of docker rate limit changes.