### PR TITLE
fix: separate subnet create vs update and check for addressPrefixes field

### DIFF
--- a/pkg/network/aci_network.go
+++ b/pkg/network/aci_network.go
@@ -137,9 +137,8 @@ func (pn *ProviderNetwork) setupNetwork(ctx context.Context, azConfig *auth.Conf
 	if currentSubnet == (aznetworkv2.Subnet{}) {
 		createNewSubnet = true
 	} else {
-		updateSubnet = true
 		// check if the current subnet is valid or if we need to create a new subnet
-		updateSubnet, err = pn.shouldCreateSubnet(currentSubnet, updateSubnet)
+		updateSubnet, err = pn.shouldCreateSubnet(currentSubnet)
 		if err != nil {
 			return err
 		}
@@ -157,7 +156,8 @@ func (pn *ProviderNetwork) setupNetwork(ctx context.Context, azConfig *auth.Conf
 	return nil
 }
 
-func (pn *ProviderNetwork) shouldCreateSubnet(currentSubnet aznetworkv2.Subnet, createSubnet bool) (bool, error) {
+func (pn *ProviderNetwork) shouldCreateSubnet(currentSubnet aznetworkv2.Subnet) (bool, error) {
+	createSubnet := true
 	//check if addressPrefix has been set
 	if currentSubnet.Properties.AddressPrefix != nil && len(*currentSubnet.Properties.AddressPrefix) > 0 {
 		if pn.SubnetCIDR == "" {

--- a/pkg/network/aci_network.go
+++ b/pkg/network/aci_network.go
@@ -179,10 +179,7 @@ func (pn *ProviderNetwork) isCurSubnetValid(currentSubnet aznetworkv2.Subnet, is
 	if currentSubnet.Properties.ServiceAssociationLinks != nil {
 		for _, l := range currentSubnet.Properties.ServiceAssociationLinks {
 			if l.Properties != nil && l.Properties.LinkedResourceType != nil {
-				if *l.Properties.LinkedResourceType == subnetDelegationService {
-					isValidSubnet = false
-					break
-				} else {
+				if *l.Properties.LinkedResourceType != subnetDelegationService {
 					return false, fmt.Errorf("unable to delegate subnet '%s' to Azure Container Instance as it is used by other Azure resource: '%v'", pn.SubnetName, l)
 				}
 			}
@@ -190,7 +187,7 @@ func (pn *ProviderNetwork) isCurSubnetValid(currentSubnet aznetworkv2.Subnet, is
 	} else {
 		for _, d := range currentSubnet.Properties.Delegations {
 			if d.Properties != nil && d.Properties.ServiceName != nil &&
-				*d.Properties.ServiceName == subnetDelegationService {
+				*d.Properties.ServiceName != subnetDelegationService {
 				isValidSubnet = false
 				break
 			}

--- a/pkg/network/aci_network.go
+++ b/pkg/network/aci_network.go
@@ -128,13 +128,12 @@ func (pn *ProviderNetwork) setupNetwork(ctx context.Context, azConfig *auth.Conf
 	var rawResponse *http.Response
 	ctxWithResp := runtime.WithCaptureResponse(ctx, &rawResponse)
 
-	updateSubnet := false
 	currentSubnet, err := pn.GetACISubnet(ctxWithResp, subnetsClient)
 	if err != nil {
 		return err
 	}
 
-	createNewSubnet := false
+	var updateSubnet, createNewSubnet bool
 	if currentSubnet == (aznetworkv2.Subnet{}) {
 		createNewSubnet = true
 	} else {

--- a/pkg/network/aci_network.go
+++ b/pkg/network/aci_network.go
@@ -128,6 +128,7 @@ func (pn *ProviderNetwork) setupNetwork(ctx context.Context, azConfig *auth.Conf
 	var rawResponse *http.Response
 	ctxWithResp := runtime.WithCaptureResponse(ctx, &rawResponse)
 
+	updateSubnet := true
 	currentSubnet, err := pn.GetACISubnet(ctxWithResp, subnetsClient)
 	if err != nil {
 		return err
@@ -136,13 +137,12 @@ func (pn *ProviderNetwork) setupNetwork(ctx context.Context, azConfig *auth.Conf
 	createNewSubnet := false
 	if currentSubnet == (aznetworkv2.Subnet{}) {
 		createNewSubnet = true
-	}
-
-	updateSubnet := true
-	// check if the current subnet is valid or if we need to create a new subnet
-	updateSubnet, err = pn.shouldCreateSubnet(currentSubnet, updateSubnet)
-	if err != nil {
-		return err
+	} else {
+		// check if the current subnet is valid or if we need to create a new subnet
+		updateSubnet, err = pn.shouldCreateSubnet(currentSubnet, updateSubnet)
+		if err != nil {
+			return err
+		}
 	}
 
 	if updateSubnet {

--- a/pkg/network/aci_network_test.go
+++ b/pkg/network/aci_network_test.go
@@ -225,7 +225,7 @@ func TestShouldCreateSubnet(t *testing.T) {
 			description:        "cannot create a subnet because both address prefix and address prefixes are missing ",
 			providerSubnetCIDR: "",
 			subnetProperties:   aznetworkv2.SubnetPropertiesFormat{},
-			expectedError:      fmt.Errorf("both AddressPrefix and AddressPrefixes for subnet '%s' are not set", pn.SubnetName),
+			expectedError:      fmt.Errorf("both AddressPrefix and AddressPrefixes field for subnet '%s' are empty or they have not been set", pn.SubnetName),
 		},
 		{
 			description:        "cannot create a subnet because Microsoft.ContainerInstance/containerGroups can't be delegated to the subnet",

--- a/pkg/network/aci_network_test.go
+++ b/pkg/network/aci_network_test.go
@@ -260,7 +260,7 @@ func TestShouldCreateSubnet(t *testing.T) {
 			pn.SubnetCIDR = tc.providerSubnetCIDR
 			currentSubnet.Properties = &tc.subnetProperties
 
-			result, err := pn.shouldCreateSubnet(currentSubnet, true)
+			result, err := pn.shouldCreateSubnet(currentSubnet)
 
 			if tc.expectedError != nil {
 				assert.Equal(t, err.Error(), tc.expectedError.Error(), "Error messages should match")

--- a/pkg/network/aci_network_test.go
+++ b/pkg/network/aci_network_test.go
@@ -260,7 +260,7 @@ func TestShouldCreateSubnet(t *testing.T) {
 			pn.SubnetCIDR = tc.providerSubnetCIDR
 			currentSubnet.Properties = &tc.subnetProperties
 
-			result, err := pn.shouldCreateSubnet(currentSubnet, true)
+			result, err := pn.isCurSubnetValid(currentSubnet, true)
 
 			if tc.expectedError != nil {
 				assert.Equal(t, err.Error(), tc.expectedError.Error(), "Error messages should match")

--- a/pkg/network/aci_network_test.go
+++ b/pkg/network/aci_network_test.go
@@ -140,7 +140,7 @@ func TestFormDNSNameserversFitsLimits(t *testing.T) {
 	}
 }
 
-func TestShouldCreateSubnet(t *testing.T) {
+func TestIsCurSubnetValid(t *testing.T) {
 	subnetName := "fakeSubnet"
 	fakeAddPrefix := "10.00.0/16"
 	providerSubnetCIDR := "10.00.0/17"
@@ -170,27 +170,27 @@ func TestShouldCreateSubnet(t *testing.T) {
 		expectedAssertions func(result bool) bool
 	}{
 		{
-			description:        "can create a subnet with address prefix set",
+			description:        "is a valid subnet with address prefix set",
 			providerSubnetCIDR: "",
 			subnetProperties: aznetworkv2.SubnetPropertiesFormat{
 				AddressPrefix: &fakeAddPrefix,
 			},
 			expectedAssertions: func(result bool) bool {
-				return assert.Equal(t, result, true, "subnet should be created")
+				return assert.Equal(t, result, true, "subnet is valid")
 			},
 		},
 		{
-			description:        "can create a subnet with address prefixes set ",
+			description:        "is a valid subnet with address prefixes set ",
 			providerSubnetCIDR: "",
 			subnetProperties: aznetworkv2.SubnetPropertiesFormat{
 				AddressPrefixes: []*string{&fakeAddPrefix},
 			},
 			expectedAssertions: func(result bool) bool {
-				return assert.Equal(t, result, true, "subnet should be created")
+				return assert.Equal(t, result, true, "subnet is valid")
 			},
 		},
 		{
-			description:        "doesn't create a subnet because subnet is already linked to Microsoft.ContainerInstance/containerGroups",
+			description:        "is a valid subnet because subnet is already linked to Microsoft.ContainerInstance/containerGroups",
 			providerSubnetCIDR: "",
 			subnetProperties: aznetworkv2.SubnetPropertiesFormat{
 				AddressPrefix: &fakeAddPrefix,
@@ -202,11 +202,11 @@ func TestShouldCreateSubnet(t *testing.T) {
 					}},
 			},
 			expectedAssertions: func(result bool) bool {
-				return assert.Equal(t, result, false, "subnet should not be created because subnet already linked to Microsoft.ContainerInstance/containerGroups")
+				return assert.Equal(t, result, true, "is a valid subnet because it's already linked to Microsoft.ContainerInstance/containerGroups")
 			},
 		},
 		{
-			description:        "doesn't create a subnet because subnet is being delegated to Microsoft.ContainerInstance/containerGroups",
+			description:        "is a valid subnet because subnet is being delegated to Microsoft.ContainerInstance/containerGroups",
 			providerSubnetCIDR: "",
 			subnetProperties: aznetworkv2.SubnetPropertiesFormat{
 				AddressPrefix: &fakeAddPrefix,
@@ -218,17 +218,17 @@ func TestShouldCreateSubnet(t *testing.T) {
 					}},
 			},
 			expectedAssertions: func(result bool) bool {
-				return assert.Equal(t, result, false, "subnet should not be created because subnet is being delegated to Microsoft.ContainerInstance/containerGroups")
+				return assert.Equal(t, result, true, "is a valid subnet because it's being delegated to Microsoft.ContainerInstance/containerGroups")
 			},
 		},
 		{
-			description:        "cannot create a subnet because both address prefix and address prefixes are missing ",
+			description:        "is not a valid subnet because both address prefix and address prefixes are missing ",
 			providerSubnetCIDR: "",
 			subnetProperties:   aznetworkv2.SubnetPropertiesFormat{},
 			expectedError:      fmt.Errorf("both AddressPrefix and AddressPrefixes for subnet '%s' are not set", pn.SubnetName),
 		},
 		{
-			description:        "cannot create a subnet because Microsoft.ContainerInstance/containerGroups can't be delegated to the subnet",
+			description:        "is not a valid subnet because Microsoft.ContainerInstance/containerGroups can't be delegated to the subnet",
 			providerSubnetCIDR: "",
 			subnetProperties: aznetworkv2.SubnetPropertiesFormat{
 				AddressPrefix:           &fakeAddPrefix,
@@ -237,7 +237,7 @@ func TestShouldCreateSubnet(t *testing.T) {
 			expectedError: fmt.Errorf("unable to delegate subnet '%s' to Azure Container Instance as it is used by other Azure resource: '%v'", pn.SubnetName, fakeServiceAssotiationLinks[0]),
 		},
 		{
-			description:        "cannot create subnet because current subnet references a route table",
+			description:        "is not a valid subnet because current subnet references a route table",
 			providerSubnetCIDR: "",
 			subnetProperties: aznetworkv2.SubnetPropertiesFormat{
 				AddressPrefix: &fakeAddPrefix,
@@ -247,7 +247,7 @@ func TestShouldCreateSubnet(t *testing.T) {
 			},
 			expectedError: fmt.Errorf("unable to delegate subnet '%s' to Azure Container Instance since it references the route table '%s'", pn.SubnetName, subnetName),
 		}, {
-			description:        "cannot create subnet because provider subnet CIDR does not match with desired subnet",
+			description:        "is not a valid subnet because provider subnet CIDR does not match with desired subnet",
 			providerSubnetCIDR: providerSubnetCIDR,
 			subnetProperties: aznetworkv2.SubnetPropertiesFormat{
 				AddressPrefix: &fakeAddPrefix,

--- a/pkg/network/aci_network_test.go
+++ b/pkg/network/aci_network_test.go
@@ -140,7 +140,7 @@ func TestFormDNSNameserversFitsLimits(t *testing.T) {
 	}
 }
 
-func TestIsCurSubnetValid(t *testing.T) {
+func TestShouldCreateSubnet(t *testing.T) {
 	subnetName := "fakeSubnet"
 	fakeAddPrefix := "10.00.0/16"
 	providerSubnetCIDR := "10.00.0/17"
@@ -170,27 +170,17 @@ func TestIsCurSubnetValid(t *testing.T) {
 		expectedAssertions func(result bool) bool
 	}{
 		{
-			description:        "is a valid subnet with address prefix set",
+			description:        "can create a subnet because all the checks pass",
 			providerSubnetCIDR: "",
 			subnetProperties: aznetworkv2.SubnetPropertiesFormat{
 				AddressPrefix: &fakeAddPrefix,
 			},
 			expectedAssertions: func(result bool) bool {
-				return assert.Equal(t, result, true, "subnet is valid")
+				return assert.Equal(t, result, true, "subnet should be created")
 			},
 		},
 		{
-			description:        "is a valid subnet with address prefixes set ",
-			providerSubnetCIDR: "",
-			subnetProperties: aznetworkv2.SubnetPropertiesFormat{
-				AddressPrefixes: []*string{&fakeAddPrefix},
-			},
-			expectedAssertions: func(result bool) bool {
-				return assert.Equal(t, result, true, "subnet is valid")
-			},
-		},
-		{
-			description:        "is a valid subnet because subnet is already linked to Microsoft.ContainerInstance/containerGroups",
+			description:        "doesn't create a subnet because subnet is already linked to Microsoft.ContainerInstance/containerGroups",
 			providerSubnetCIDR: "",
 			subnetProperties: aznetworkv2.SubnetPropertiesFormat{
 				AddressPrefix: &fakeAddPrefix,
@@ -202,11 +192,11 @@ func TestIsCurSubnetValid(t *testing.T) {
 					}},
 			},
 			expectedAssertions: func(result bool) bool {
-				return assert.Equal(t, result, true, "is a valid subnet because it's already linked to Microsoft.ContainerInstance/containerGroups")
+				return assert.Equal(t, result, false, "subnet should not be created because subnet already linked to Microsoft.ContainerInstance/containerGroups")
 			},
 		},
 		{
-			description:        "is a valid subnet because subnet is being delegated to Microsoft.ContainerInstance/containerGroups",
+			description:        "doesn't create a subnet because subnet is being delegated to Microsoft.ContainerInstance/containerGroups",
 			providerSubnetCIDR: "",
 			subnetProperties: aznetworkv2.SubnetPropertiesFormat{
 				AddressPrefix: &fakeAddPrefix,
@@ -218,17 +208,11 @@ func TestIsCurSubnetValid(t *testing.T) {
 					}},
 			},
 			expectedAssertions: func(result bool) bool {
-				return assert.Equal(t, result, true, "is a valid subnet because it's being delegated to Microsoft.ContainerInstance/containerGroups")
+				return assert.Equal(t, result, false, "subnet should not be created because subnet is being delegated to Microsoft.ContainerInstance/containerGroups")
 			},
 		},
 		{
-			description:        "is not a valid subnet because both address prefix and address prefixes are missing ",
-			providerSubnetCIDR: "",
-			subnetProperties:   aznetworkv2.SubnetPropertiesFormat{},
-			expectedError:      fmt.Errorf("both AddressPrefix and AddressPrefixes for subnet '%s' are not set", pn.SubnetName),
-		},
-		{
-			description:        "is not a valid subnet because Microsoft.ContainerInstance/containerGroups can't be delegated to the subnet",
+			description:        "cannot create a subnet because Microsoft.ContainerInstance/containerGroups can't be delegated to the subnet",
 			providerSubnetCIDR: "",
 			subnetProperties: aznetworkv2.SubnetPropertiesFormat{
 				AddressPrefix:           &fakeAddPrefix,
@@ -237,7 +221,7 @@ func TestIsCurSubnetValid(t *testing.T) {
 			expectedError: fmt.Errorf("unable to delegate subnet '%s' to Azure Container Instance as it is used by other Azure resource: '%v'", pn.SubnetName, fakeServiceAssotiationLinks[0]),
 		},
 		{
-			description:        "is not a valid subnet because current subnet references a route table",
+			description:        "cannot create subnet because current subnet references a route table",
 			providerSubnetCIDR: "",
 			subnetProperties: aznetworkv2.SubnetPropertiesFormat{
 				AddressPrefix: &fakeAddPrefix,
@@ -247,7 +231,7 @@ func TestIsCurSubnetValid(t *testing.T) {
 			},
 			expectedError: fmt.Errorf("unable to delegate subnet '%s' to Azure Container Instance since it references the route table '%s'", pn.SubnetName, subnetName),
 		}, {
-			description:        "is not a valid subnet because provider subnet CIDR does not match with desired subnet",
+			description:        "cannot create subnet because provider subnet CIDR does not match with desired subnet",
 			providerSubnetCIDR: providerSubnetCIDR,
 			subnetProperties: aznetworkv2.SubnetPropertiesFormat{
 				AddressPrefix: &fakeAddPrefix,
@@ -260,7 +244,7 @@ func TestIsCurSubnetValid(t *testing.T) {
 			pn.SubnetCIDR = tc.providerSubnetCIDR
 			currentSubnet.Properties = &tc.subnetProperties
 
-			result, err := pn.isCurSubnetValid(currentSubnet, true)
+			result, err := pn.shouldCreateNewSubnet(currentSubnet, true)
 
 			if tc.expectedError != nil {
 				assert.Equal(t, err.Error(), tc.expectedError.Error(), "Error messages should match")

--- a/pkg/network/aci_network_test.go
+++ b/pkg/network/aci_network_test.go
@@ -170,10 +170,20 @@ func TestShouldCreateSubnet(t *testing.T) {
 		expectedAssertions func(result bool) bool
 	}{
 		{
-			description:        "can create a subnet because all the checks pass",
+			description:        "can create a subnet with address prefix set",
 			providerSubnetCIDR: "",
 			subnetProperties: aznetworkv2.SubnetPropertiesFormat{
 				AddressPrefix: &fakeAddPrefix,
+			},
+			expectedAssertions: func(result bool) bool {
+				return assert.Equal(t, result, true, "subnet should be created")
+			},
+		},
+		{
+			description:        "can create a subnet with address prefixes set ",
+			providerSubnetCIDR: "",
+			subnetProperties: aznetworkv2.SubnetPropertiesFormat{
+				AddressPrefixes: []*string{&fakeAddPrefix},
 			},
 			expectedAssertions: func(result bool) bool {
 				return assert.Equal(t, result, true, "subnet should be created")
@@ -210,6 +220,12 @@ func TestShouldCreateSubnet(t *testing.T) {
 			expectedAssertions: func(result bool) bool {
 				return assert.Equal(t, result, false, "subnet should not be created because subnet is being delegated to Microsoft.ContainerInstance/containerGroups")
 			},
+		},
+		{
+			description:        "cannot create a subnet because both address prefix and address prefixes are missing ",
+			providerSubnetCIDR: "",
+			subnetProperties:   aznetworkv2.SubnetPropertiesFormat{},
+			expectedError:      fmt.Errorf("both AddressPrefix and AddressPrefixes for subnet '%s' are not set", pn.SubnetName),
 		},
 		{
 			description:        "cannot create a subnet because Microsoft.ContainerInstance/containerGroups can't be delegated to the subnet",

--- a/pkg/network/aci_network_test.go
+++ b/pkg/network/aci_network_test.go
@@ -170,10 +170,20 @@ func TestShouldCreateSubnet(t *testing.T) {
 		expectedAssertions func(result bool) bool
 	}{
 		{
-			description:        "can create a subnet because all the checks pass",
+			description:        "can create a subnet with address prefix set",
 			providerSubnetCIDR: "",
 			subnetProperties: aznetworkv2.SubnetPropertiesFormat{
 				AddressPrefix: &fakeAddPrefix,
+			},
+			expectedAssertions: func(result bool) bool {
+				return assert.Equal(t, result, true, "subnet should be created")
+			},
+		},
+		{
+			description:        "can create a subnet with address prefixes set ",
+			providerSubnetCIDR: "",
+			subnetProperties: aznetworkv2.SubnetPropertiesFormat{
+				AddressPrefixes: []*string{&fakeAddPrefix},
 			},
 			expectedAssertions: func(result bool) bool {
 				return assert.Equal(t, result, true, "subnet should be created")
@@ -212,6 +222,12 @@ func TestShouldCreateSubnet(t *testing.T) {
 			},
 		},
 		{
+			description:        "cannot create a subnet because both address prefix and address prefixes are missing ",
+			providerSubnetCIDR: "",
+			subnetProperties:   aznetworkv2.SubnetPropertiesFormat{},
+			expectedError:      fmt.Errorf("both AddressPrefix and AddressPrefixes for subnet '%s' are not set", pn.SubnetName),
+		},
+		{
 			description:        "cannot create a subnet because Microsoft.ContainerInstance/containerGroups can't be delegated to the subnet",
 			providerSubnetCIDR: "",
 			subnetProperties: aznetworkv2.SubnetPropertiesFormat{
@@ -244,7 +260,7 @@ func TestShouldCreateSubnet(t *testing.T) {
 			pn.SubnetCIDR = tc.providerSubnetCIDR
 			currentSubnet.Properties = &tc.subnetProperties
 
-			result, err := pn.shouldCreateNewSubnet(currentSubnet, true)
+			result, err := pn.shouldCreateSubnet(currentSubnet, true)
 
 			if tc.expectedError != nil {
 				assert.Equal(t, err.Error(), tc.expectedError.Error(), "Error messages should match")


### PR DESCRIPTION
- Added a check for subnet properties.AddressPrefixes incase properties.AddressPrefix is not set and added necessary unit tests
- To differentiate between subnet create vs update scenario:
  - changed the existing "createSubnet" boolean to "updateSubnet" to minimize confusion - this bool indicates that an update is needed
  - introduced new boolean "createNewSubnet" which will only be set to true if we cannot retrieve the ACI subnet from GetACISubnet function
  - Updated function "CreateACISubnet" to "CreateOrUpdateACISubnet" and distinguished create vs update scenario using the "createNewSubnet" boolean from above
  - updated logic so addressPrefix/addressPrefixes is only set on create