### PR TITLE
ci: Add the missing checkout action and pass the release version

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -114,4 +114,5 @@ jobs:
     uses: ./.github/workflows/publish-init-container-image.yml
     with:
       registry: ${{ needs.export-registry.outputs.registry }}
+      release_version: ${{ needs.check-tag.outputs.release-tag }}
       init_container_version: ${{ needs.check-tag.outputs.init-tag }}

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -25,6 +25,12 @@ jobs:
   publish-images:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
+          ref: {{ inputs.release_version }}
+
       - name: Login to ${{ inputs.registry }}
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
         with:
@@ -36,11 +42,12 @@ jobs:
         run: |
           ver=${{ inputs.release_version }}
           echo "IMG_TAG=${ver#"v"}" >> $GITHUB_ENV
+
       - name: Build and push image
         run: |
           OUTPUT_TYPE=type=registry make docker-build-image
         env:
-          VERSION: ${{ env.IMG_TAG }}
+          IMG_TAG: ${{ env.IMG_TAG }}
           REGISTRY: ${{ inputs.registry }}
 
       - name: Scan ${{ inputs.registry }}/${{ env.IMAGE_NAME }}:${{ env.IMG_TAG }}

--- a/.github/workflows/publish-init-container-image.yml
+++ b/.github/workflows/publish-init-container-image.yml
@@ -6,7 +6,11 @@ on:
         description: 'Which registry are we pushing the image to?'
         type: string
         required: true
-      init_container_version:
+    release_version:
+      description: 'Which version are we creating an image for?'
+      type: string
+      required: true
+    init_container_version:
         description: 'Which init container version are we creating an image for?'
         required: true
         type: string
@@ -29,7 +33,7 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-          ref: ${{ steps.get-tag.outputs.tag }}
+          ref: { { inputs.release_version } }
 
       - name: Login to ${{ inputs.registry }}
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
@@ -42,6 +46,7 @@ jobs:
         run: |
           ver=${{ inputs.init_container_version }}
           echo "INIT_IMG_TAG=${ver#"v"}" >> $GITHUB_ENV
+
       - name: Build and push image
         run: |
           OUTPUT_TYPE=type=registry make docker-build-init-image


### PR DESCRIPTION
- In `Publish the Azure Virtual Kubelet image` pipeline, the checkout action was missing
- Add the release version variable to `Publish the init validation image` pipeline to checkout the right tag.