### PR TITLE
fix: correct init image tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ TEST_CREDENTIALS_JSON ?= $(TEST_CREDENTIALS_DIR)/credentials.json
 TEST_LOGANALYTICS_JSON ?= $(TEST_CREDENTIALS_DIR)/loganalytics.json
 export TEST_CREDENTIALS_JSON TEST_LOGANALYTICS_JSON TEST_AKS_CREDENTIALS_JSON
 
-VERSION ?= v1.6.2
+VERSION ?= v1.6.1
 REGISTRY ?= ghcr.io
 IMG_NAME ?= virtual-kubelet
 INIT_IMG_NAME ?= init-validation
@@ -35,7 +35,7 @@ E2E_CLUSTER_NAME := $(CLUSTER_NAME)
 OUTPUT_TYPE ?= type=docker
 BUILDPLATFORM ?= linux/amd64
 IMG_TAG ?= $(subst v,,$(VERSION))
-INIT_IMG_TAG ?= v0.3.0
+INIT_IMG_TAG ?= 0.2.0
 
 BUILD_DATE ?= $(shell date '+%Y-%m-%dT%H:%M:%S')
 VERSION_FLAGS := "-ldflags=-X main.buildVersion=$(IMG_TAG) -X main.buildTime=$(BUILD_DATE)"

--- a/charts/virtual-kubelet/values.yaml
+++ b/charts/virtual-kubelet/values.yaml
@@ -8,7 +8,7 @@ image:
 initImage:
   repository: mcr.microsoft.com
   name: oss/virtual-kubelet/init-validation
-  initTag: v0.3.0
+  initTag: 0.3.0
   pullPolicy: IfNotPresent
 
 namespace: vk-azure-aci

--- a/hack/e2e/aks-addon.sh
+++ b/hack/e2e/aks-addon.sh
@@ -185,7 +185,7 @@ helm install \
     --set "image.name=${IMG_REPO}" \
     --set "initImage.repository=${IMG_URL}"  \
     --set "initImage.name=${INIT_IMG_REPO}" \
-    --set "initImage.tag=${INIT_IMG_TAG}" \
+    --set "initImage.initTag=${INIT_IMG_TAG}" \
     --set "nodeName=${TEST_WINDOWS_NODE_NAME}" \
     --set "providers.azure.masterUri=$MASTER_URI" \
     --set "providers.azure.managedIdentityID=$ACI_USER_IDENTITY" \

--- a/hack/e2e/aks.sh
+++ b/hack/e2e/aks.sh
@@ -185,7 +185,7 @@ helm install \
     --set "image.tag=${IMG_TAG}" \
     --set "initImage.repository=${IMG_URL}"  \
     --set "initImage.name=${INIT_IMG_REPO}" \
-    --set "initImage.tag=${INIT_IMG_TAG}" \
+    --set "initImage.initTag=${INIT_IMG_TAG}" \
     --set "nodeName=${TEST_NODE_NAME}" \
     --set providers.azure.vnet.enabled=true \
     --set "providers.azure.vnet.subnetName=$ACI_SUBNET_NAME" \

--- a/hack/e2e/aks.sh
+++ b/hack/e2e/aks.sh
@@ -216,7 +216,7 @@ helm install \
     --set "image.tag=${IMG_TAG}" \
     --set "initImage.repository=${IMG_URL}"  \
     --set "initImage.name=${INIT_IMG_REPO}" \
-    --set "initImage.tag=${INIT_IMG_TAG}" \
+    --set "initImage.initTag=${INIT_IMG_TAG}" \
     --set "nodeName=${TEST_WINDOWS_NODE_NAME}" \
     --set "providers.azure.masterUri=$MASTER_URI" \
     "$WIN_CHART_NAME" \


### PR DESCRIPTION
- remove the 'v' in front of the tag
- update e2e scripts to use the right helm variable for init image tag: initImage.initTag