### PR TITLE
ci: update regex for init container version 

### DIFF
--- a/.github/workflows/create-release-pull-request.yml
+++ b/.github/workflows/create-release-pull-request.yml
@@ -28,7 +28,7 @@ jobs:
       - name: validate version
         run: |
           echo "${{ github.event.inputs.release_version }}" | grep -E 'v[0-9]+\.[0-9]+\.[0-9]+$'
-          echo "${{ github.event.inputs.init_container_version }}" | grep -E 'v[0-9]+\.[0-9]+\.[0-9]+$'
+          echo "${{ github.event.inputs.init_container_version }}" | grep -E '[0-9]+\.[0-9]+\.[0-9]+$'
           echo "${{ github.event.inputs.based_on_branch }}" | grep -E '^(master|release-[0-9]+\.[0-9]+\.[0-9]+-[0-9]+\.[0-9]+\.[0-9]+)$'
 
       - uses: actions/checkout@v4


### PR DESCRIPTION
Leaving out the 'v' when reading init image version so the correct value is populated for helm variable initImage.initTag in order for the init container to pull the correct image