### PR TITLE
fix: Handle response error when nil

### DIFF
--- a/pkg/client/client_apis.go
+++ b/pkg/client/client_apis.go
@@ -165,7 +165,11 @@ func (a *AzClientsAPIs) GetContainerGroupInfo(ctx context.Context, resourceGroup
 			rawResponse != nil && rawResponse.StatusCode == http.StatusNotFound {
 			return nil, errdefs.NotFound("cg is not found")
 		}
-		logger.Errorf("an error has occurred while getting container group info %s, status code %d", cgName, rawResponse.StatusCode)
+		if rawResponse != nil {
+			logger.Errorf("an error has occurred while getting container group info %s, status code %d", cgName, rawResponse.StatusCode)
+		} else {
+			logger.Errorf("an error has occurred while getting container group info %s, status code unknown: %v", cgName, err)
+		}
 		return nil, err
 	}
 

--- a/pkg/network/aci_network.go
+++ b/pkg/network/aci_network.go
@@ -214,6 +214,7 @@ func (pn *ProviderNetwork) GetACISubnet(ctx context.Context, subnetsClient *azne
 		}
 
 		if errors.As(err, &respErr) &&
+			respErr.RawResponse != nil &&
 			respErr.RawResponse.StatusCode == http.StatusNotFound &&
 			pn.SubnetCIDR == "" {
 			return aznetworkv2.Subnet{}, fmt.Errorf("subnet '%s' is not found in vnet '%s' in resource group '%s' and subscription '%s' and subnet CIDR is not specified", pn.SubnetName, pn.VnetName, pn.VnetResourceGroup, pn.VnetSubscriptionID)


### PR DESCRIPTION
- In `GetACISubnet` function, the response error is not handled by `errors.As(err, &respErr)`, which will cause nil pointer dereference when the response error is nil.

- `runtime.WithCaptureResponse` is deprecated in favor of `policy.WithCaptureResponse`